### PR TITLE
WIP on Issue 78

### DIFF
--- a/lib/screens/EditNoteScreen.tsx
+++ b/lib/screens/EditNoteScreen.tsx
@@ -279,8 +279,9 @@ const EditNoteScreen: React.FC<EditNoteScreenProps> = ({
         <ScrollView
           nestedScrollEnabled={true}
           showsVerticalScrollIndicator={false}
-          style={{ overflow: "hidden", paddingTop: 10, paddingBottom: 100 }}
+          style={{overflow: "hidden", paddingTop: 10, paddingBottom: 100 }}
           ref={scrollViewRef}
+          scrollEnabled={true}
         >
           <View key="Tags Container">
             <ScrollView
@@ -380,9 +381,14 @@ const EditNoteScreen: React.FC<EditNoteScreenProps> = ({
               placeholder="Write your note here"
               onChange={(text) => setText(text)}
               initialContentHTML={text}
-              //at first glance I believe changes need to be made here.
               onCursorPosition={(position) => {
-                handleScroll(position);
+                if(scrollViewRef.current){
+                  scrollViewRef.current.scrollTo({
+                    y: position - 100,
+                    animated: true,
+                  });
+                }
+
               }}
             />
             <View style={{ height: keyboardOpen ? 400 : 90 }} />


### PR DESCRIPTION

![Screenshot_20231001-214332](https://github.com/oss-slu/lrda_mobile/assets/89712138/5dab9f22-6d60-4a6b-9d0b-9a5799122c1f)
The scroller is currently bugged and does not scroll down.
The changes in code can be seen when editing a note. There is no major difference than the main bugged code as I am still somewhat unsure what is causing this issue. Note: The position is -100 in this commit, however, I have tried with +100 as well. This function was also just a test at overriding the already used callback function. I also removed an irrelevant comment