### PR TITLE
(WIS99) StillProblemTimepicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LRDA Mobile
+a# LRDA Mobile
 
 ## Overview
 LRDA Mobile is the mobile app for the Lived Religion Application (LRDA), designed to provide ethnographers with an accessible platform to share their data worldwide. Built using React Native and TypeScript, this app connects to the Rerum Website to facilitate seamless data integration.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-a# LRDA Mobile
+# LRDA Mobile
 
 ## Overview
 LRDA Mobile is the mobile app for the Lived Religion Application (LRDA), designed to provide ethnographers with an accessible platform to share their data worldwide. Built using React Native and TypeScript, this app connects to the Rerum Website to facilitate seamless data integration.

--- a/lib/components/time.tsx
+++ b/lib/components/time.tsx
@@ -61,17 +61,14 @@ export default function LocationWindow({
     const currentTime = selectedTime || time;
   
     if (Platform.OS === 'android') {
-      // For Android, check if the event is dismissed
       if (event.type === 'dismissed') {
         setShowTimePicker(false); 
       } else {
         setChosenTime(currentTime);
-        // Consider introducing a delay or additional flag here
         setShowTimePicker(false); 
         setShowDatePicker(true); 
       }
     } else {
-      // For iOS, just set the chosen time
       setChosenTime(currentTime);
       setIsDateTimeSelected(true);
     }

--- a/lib/components/time.tsx
+++ b/lib/components/time.tsx
@@ -49,11 +49,16 @@ export default function LocationWindow({
 
   const onChangeDate = (event: any, selectedDate: any) => {
     const currentDate = selectedDate || date;
-    setChosenDate(currentDate);
     if (Platform.OS === 'android') {
-      setShowDatePicker(false); 
-      setShowTimePicker(false); 
-      setIsDateTimeSelected(true);
+      if (event.type === 'dismissed') {
+        setShowDatePicker(false); 
+      } else {
+        setChosenDate(currentDate);
+        setShowDatePicker(false);
+        setIsDateTimeSelected(true); 
+      }
+    } else {
+      setChosenDate(currentDate);
     }
   };
 
@@ -62,15 +67,14 @@ export default function LocationWindow({
   
     if (Platform.OS === 'android') {
       if (event.type === 'dismissed') {
-        setShowTimePicker(false); 
+        setShowTimePicker(false);
       } else {
         setChosenTime(currentTime);
         setShowTimePicker(false); 
-        setShowDatePicker(true); 
+        setShowDatePicker(true);
       }
     } else {
       setChosenTime(currentTime);
-      setIsDateTimeSelected(true);
     }
   };
   
@@ -86,6 +90,10 @@ export default function LocationWindow({
     setTime(combinedDate);
     setSavedDateTime(combinedDate); 
     setShowPicker(false);
+    setShowDatePicker(false); 
+    setShowTimePicker(false);
+    setIsDateTimeSelected(false); 
+
   };
 
   return (
@@ -116,7 +124,7 @@ export default function LocationWindow({
           )}
         {isDateTimeSelected && Platform.OS === 'android' && (
         <Text style={styles.selectedDateTimeLabel}>
-          Selected: {formatToLocalDateString(new Date(chosenDate.getFullYear(), chosenDate.getMonth(), chosenDate.getDate(), chosenTime.getHours(), chosenTime.getMinutes()))}
+         Selected: {formatToLocalDateString(new Date(chosenDate.getFullYear(), chosenDate.getMonth(), chosenDate.getDate(), chosenTime.getHours(), chosenTime.getMinutes()))}
         </Text>
       )}
       <View style={styles.button}>

--- a/lib/components/time.tsx
+++ b/lib/components/time.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect} from "react";
 import { View, Text, StyleSheet ,Button} from "react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
 
@@ -38,6 +38,8 @@ export default function LocationWindow({
   const [chosenDate, setChosenDate] = useState(new Date());
   const [chosenTime, setChosenTime] = useState(new Date());
   const [showPicker, setShowPicker] = useState(false);
+  const [showDatePicker, setShowDatePicker] = useState(false);
+  const [showTimePicker, setShowTimePicker] = useState(false);
   const [savedDateTime, setSavedDateTime] = useState<null | Date>(null);
 
   useEffect(() => {
@@ -47,11 +49,13 @@ export default function LocationWindow({
   const onChangeDate = (event: any, selectedDate: any) => {
     const currentDate = selectedDate || date;
     setChosenDate(currentDate);
+    setShowDatePicker(false);
   };
 
   const onChangeTime = (event: any, selectedTime: any) => {
     const currentTime = selectedTime || date;
     setChosenTime(currentTime);
+    setShowTimePicker(false);
   };
 
   const saveDateTime = () => {
@@ -72,22 +76,26 @@ export default function LocationWindow({
       <Text style={styles.label}>Date & Time</Text>
       {showPicker ? (
           <View style={styles.dateTimePickerContainer}>
-    <DateTimePicker
-      testID="datePicker"
-      value={chosenDate}
-      mode={"date"}
-      is24Hour={true}
-      display="default"
-      onChange={onChangeDate}
-    />
-    <DateTimePicker
-      testID="timePicker"
-      value={chosenTime}
-      mode={"time"}
-      is24Hour={true}
-      display="default"
-      onChange={onChangeTime}
-    />
+    {showDatePicker && (
+            <DateTimePicker
+              testID="datePicker"
+              value={date}
+              mode="date"
+              is24Hour={true}
+              display="default"
+              onChange={onChangeDate}
+            />
+          )}
+    {showTimePicker && (
+            <DateTimePicker
+              testID="timePicker"
+              value={date}
+              mode="time"
+              is24Hour={true}
+              display="default"
+              onChange={onChangeTime}
+            />
+          )}
       <Button title="Save" onPress={saveDateTime} />
     </View>
 ) : (
@@ -97,7 +105,7 @@ export default function LocationWindow({
         {formatToLocalDateString(savedDateTime || time)}
       </Text>
     </View>
-    <Button title="Select Date & Time" onPress={() => setShowPicker(true)} />
+    <Button title="Select Date & Time" onPress={() => { setShowPicker(true); setShowDatePicker(true); setShowTimePicker(true); }} />
   </View>
 )}
     </View>
@@ -135,4 +143,3 @@ const styles = StyleSheet.create({
     fontSize: 16,
   },
 });
-

--- a/lib/components/time.tsx
+++ b/lib/components/time.tsx
@@ -93,7 +93,7 @@ export default function LocationWindow({
     <View style={styles.container}>
       <Text style={styles.label}>Date & Time</Text>
       {showPicker ? (
-          <View style={styles.dateTimePickerContainer}>
+        <View style={Platform.OS === 'ios' ? styles.IOSdateTimePickerContainer : styles.dateTimePickerContainer}>
     {showDatePicker && (
             <DateTimePicker
               testID="datePicker"
@@ -139,7 +139,7 @@ export default function LocationWindow({
 
 const styles = StyleSheet.create({
   container: {
-    height: 100,
+    height: 110,
     justifyContent: "center",
     alignItems: "center",
     padding: 20,
@@ -161,6 +161,9 @@ const styles = StyleSheet.create({
     borderRadius: 5,
     paddingHorizontal: 10,
   },
+  IOSdateTimePickerContainer: {
+    flexDirection: "row", 
+  },
   dateTimePickerContainer: {
     flexDirection: "column", 
   },
@@ -173,6 +176,7 @@ const styles = StyleSheet.create({
   },
   selectedDateTimeLabel: {
     marginBottom: 10, 
+    fontSize: 16,
     textAlign: 'center',
   },
   button: {


### PR DESCRIPTION
Since timepicker cannot be exited on Android, I currently choose to hide timepicker after selecting a time. Currently, Android can save the time normally before exiting, but this method will cause IOS to be unable to select the time normally. I may need to use the react platform function to solve this problem.
<img width="247" alt="Screenshot 2023-11-13 at 11 52 22 AM" src="https://github.com/oss-slu/lrda_mobile/assets/102174217/fbefab38-bc8f-4621-9bc9-bff89ab058dc">
