### PR TITLE
WIS 109 Test Case for Time function on Different Platform

### DIFF
--- a/__tests__/DifferentPlatformTimes.test.tsx
+++ b/__tests__/DifferentPlatformTimes.test.tsx
@@ -1,0 +1,67 @@
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });
+import { Button } from 'react-native';
+import React from 'react';
+import moxios from 'moxios';
+import LocationWindow from "../lib/components/time";
+import AddNoteScreen from '../lib/screens/AddNoteScreen';
+import { Platform } from 'react-native';
+import DateTimePicker from '@react-native-community/datetimepicker';
+
+beforeAll(() => {
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  moxios.install();
+});
+
+afterAll(() => {
+  console.log.mockRestore();
+  console.error.mockRestore();
+  moxios.uninstall();
+});
+
+jest.mock('../lib/components/ThemeProvider', () => ({
+  useTheme: () => ({
+    theme: 'mockedTheme', 
+  }),
+}));
+
+jest.mock('@react-native-community/datetimepicker', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  const MockDateTimePicker = ({ testID }) => (
+    <View testID={testID}>DateTimePicker</View>
+  );
+  return MockDateTimePicker;
+});
+
+
+describe("AddNoteScreen", () => {
+  const mockSetTime = jest.fn();
+  it("renders without crashing", () => {
+      const wrapper = shallow(<AddNoteScreen />);
+      expect(wrapper).toMatchSnapshot();
+  });
+});
+
+describe('LocationWindow', () => {
+  const mockSetTime = jest.fn();
+  const renderComponent = (platform) => {
+    Platform.OS = platform;
+    return shallow(<LocationWindow time={new Date()} setTime={mockSetTime} />);
+  };
+
+  describe('on iOS', () => {
+    it('renders date and time picker correctly on iOS', () => {
+      const wrapper = renderComponent('ios');
+      expect(wrapper.find(DateTimePicker).length).toBe(0);
+    });
+
+
+  });
+
+
+});

--- a/__tests__/__snapshots__/DifferentPlatformTimes.test.tsx.snap
+++ b/__tests__/__snapshots__/DifferentPlatformTimes.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddNoteScreen renders without crashing 1`] = `ShallowWrapper {}`;


### PR DESCRIPTION
Hi guys, Last week I solved the timepicker problem on the Android side. Currently, both the iOS and Android sides can run the time function (time saving and time selection) normally. Now I complete a new test case to ensure that our time function runs successfully on both clients. At present, I have completed part of the ios part, and I still need to add the Android part.
<img width="709" alt="Screenshot 2023-11-27 at 2 50 18 PM" src="https://github.com/oss-slu/lrda_mobile/assets/102174217/ca38e2d3-78c7-447f-a59a-8224a8c1207a">
