### PR TITLE
Map starting location

### DIFF
--- a/lib/screens/mapPage/ExploreLoadingScreen.tsx
+++ b/lib/screens/mapPage/ExploreLoadingScreen.tsx
@@ -4,12 +4,12 @@ const ExploreLoadingScreen = () => {
   return (
     <View style={styles.centered}>
       <ActivityIndicator size="large" color="#0000ff" />
-      <Text>Loading your location...</Text>
+      <View style={{padding: 5}}></View>
+      <Text style={{ color: 'white' }}>Loading your location...</Text>
     </View>
   );
 }
 
-// Add this style to your stylesheet
 const styles = StyleSheet.create({
   centered: {
     flex: 1,

--- a/lib/screens/mapPage/ExploreLoadingScreen.tsx
+++ b/lib/screens/mapPage/ExploreLoadingScreen.tsx
@@ -1,11 +1,14 @@
 import { ActivityIndicator, View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '../../components/ThemeProvider';
 
 const ExploreLoadingScreen = () => {
+  const { theme, isDarkmode } = useTheme();
+
   return (
     <View style={styles.centered}>
       <ActivityIndicator size="large" color="#0000ff" />
       <View style={{padding: 5}}></View>
-      <Text style={{ color: 'white' }}>Loading your location...</Text>
+      <Text style={{ color: theme.text }}>Loading your location...</Text>
     </View>
   );
 }

--- a/lib/screens/mapPage/ExploreLoadingScreen.tsx
+++ b/lib/screens/mapPage/ExploreLoadingScreen.tsx
@@ -1,0 +1,21 @@
+import { ActivityIndicator, View, Text, StyleSheet } from 'react-native';
+
+const ExploreLoadingScreen = () => {
+  return (
+    <View style={styles.centered}>
+      <ActivityIndicator size="large" color="#0000ff" />
+      <Text>Loading your location...</Text>
+    </View>
+  );
+}
+
+// Add this style to your stylesheet
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  }
+});
+
+export default ExploreLoadingScreen;

--- a/lib/screens/mapPage/ExploreScreen.js
+++ b/lib/screens/mapPage/ExploreScreen.js
@@ -354,8 +354,8 @@ const ExploreScreen = () => {
           region: {
             latitude,
             longitude,
-            latitudeDelta: 0.04864195044303443,
-            longitudeDelta: 0.040142817690068,
+            latitudeDelta: 0.058370340531641314,
+            longitudeDelta: 0.0481713812280816,
           }
         }));
       }

--- a/lib/screens/mapPage/ExploreScreen.js
+++ b/lib/screens/mapPage/ExploreScreen.js
@@ -364,7 +364,6 @@ const ExploreScreen = () => {
     return () => isMounted = false;
   }, []);
   
-
   let mapIndex = 0;
   let mapAnimation = new Animated.Value(0);
 

--- a/lib/screens/mapPage/ExploreScreen.js
+++ b/lib/screens/mapPage/ExploreScreen.js
@@ -21,6 +21,7 @@ import ApiService from "../../utils/api_calls";
 import Constants from 'expo-constants';
 import { Keyboard } from 'react-native';
 import { useTheme } from '../../components/ThemeProvider';
+import ExploreLoadingScreen from "./ExploreLoadingScreen";
 
 const { width } = Dimensions.get("window");
 const CARD_HEIGHT = 220;
@@ -35,7 +36,6 @@ const ExploreScreen = () => {
   const [mapType, setMapType] = useState('standard'); // New state for map type
   const { theme, isDarkmode } = useTheme();
   const [showMapTypeOptions, setShowMapTypeOptions] = useState(false);
-
   
   const toggleMapTypeOptions = () => {
     setShowMapTypeOptions(prevState => !prevState);
@@ -274,61 +274,96 @@ const ExploreScreen = () => {
     },
   });
 
-const [state, setState] = useState({
-  markers: [],
-  categories: [
-    {
-      name: "Events",
-      icon: (
-        <MaterialCommunityIcons
-          style={styles.chipsIcon}
-          name="calendar-multiple"
-          size={18}
-        />
-      ),
-    },
-    {
-      name: "Cultural",
-      icon: (
-        <Ionicons
-          name="ios-globe-outline"
-          style={styles.chipsIcon}
-          size={18}
-        />
-      ),
-    },
-    {
-      name: "History",
-      icon: <Ionicons name="md-time" style={styles.chipsIcon} size={18} />,
-    },
-    {
-      name: "Modern",
-      icon: (
-        <MaterialCommunityIcons
-          name="city-variant-outline"
-          style={styles.chipsIcon}
-          size={18}
-        />
-      ),
-    },
-    {
-      name: "Religious",
-      icon: (
-        <MaterialCommunityIcons
-          name="church"
-          style={styles.chipsIcon}
-          size={15}
-        />
-      ),
-    },
-  ],
-  region: {
-    latitude: 38.631393,
-    longitude: -90.192226,
-    latitudeDelta: 0.04864195044303443,
-    longitudeDelta: 0.040142817690068,
-  },
-});
+  const [state, setState] = useState({
+    markers: [],
+    categories: [
+      {
+        name: "Events",
+        icon: (
+          <MaterialCommunityIcons
+            style={styles.chipsIcon}
+            name="calendar-multiple"
+            size={18}
+          />
+        ),
+      },
+      {
+        name: "Cultural",
+        icon: (
+          <Ionicons
+            name="ios-globe-outline"
+            style={styles.chipsIcon}
+            size={18}
+          />
+        ),
+      },
+      {
+        name: "History",
+        icon: <Ionicons name="md-time" style={styles.chipsIcon} size={18} />,
+      },
+      {
+        name: "Modern",
+        icon: (
+          <MaterialCommunityIcons
+            name="city-variant-outline"
+            style={styles.chipsIcon}
+            size={18}
+          />
+        ),
+      },
+      {
+        name: "Religious",
+        icon: (
+          <MaterialCommunityIcons
+            name="church"
+            style={styles.chipsIcon}
+            size={15}
+          />
+        ),
+      },
+    ],
+    region: null
+  });
+
+  useEffect(() => {
+    let isMounted = true;
+  
+    (async () => {
+      let { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== "granted") {
+        Alert.alert(
+          "Permission Denied",
+          "Permission to access location was denied. This is required on this page",
+          [{
+            text: "Try Again",
+            onPress: () => {
+              (async () => {
+                await Location.requestForegroundPermissionsAsync();
+              })();
+            }
+          }]
+        );
+        return; // Early return to avoid executing further code without permission
+      }
+  
+      let location = await Location.getCurrentPositionAsync({});
+      const { latitude, longitude } = location.coords;
+      if (isMounted) {
+        setState(prevState => ({
+          ...prevState,
+          region: {
+            latitude,
+            longitude,
+            latitudeDelta: 0.04864195044303443,
+            longitudeDelta: 0.040142817690068,
+          }
+        }));
+      }
+    })();
+  
+    return () => isMounted = false;
+  }, []);
+  
 
   let mapIndex = 0;
   let mapAnimation = new Animated.Value(0);
@@ -360,49 +395,7 @@ const [state, setState] = useState({
         }
       }, 10);
     });
-  });
-
-  useEffect(() => {
-    let isMounted = true;
-  
-    (async () => {
-      let { status } = await Location.requestForegroundPermissionsAsync();
-      if (status !== "granted") {
-        Alert.alert(
-          "Permission Denied",
-          "Permission to access location was denied. This is required on this page",
-          [
-            {
-              text: "Try Again",
-              onPress: () => {
-                (async () => {
-                  await Location.requestForegroundPermissionsAsync();
-                })();
-              }
-            },
-          ]
-        );
-        return; // Early return to avoid executing further code without permission
-      }
-  
-      let location = await Location.getCurrentPositionAsync({});
-      const { latitude, longitude } = location.coords;
-      if (isMounted) {
-        setState(prevState => ({
-          ...prevState,
-          region: {
-            latitude,
-            longitude,
-            latitudeDelta: 0.04864195044303443,
-            longitudeDelta: 0.040142817690068,
-          }
-        }));
-      }
-    })();
-  
-    return () => isMounted = false;
-  }, []);
-  
+  });  
 
   const interpolations = state.markers.map((marker, index) => {
     const inputRange = [
@@ -422,6 +415,7 @@ const [state, setState] = useState({
 
   const onMarkerPress = (mapEventData) => {
     const markerID = mapEventData._targetInst.return.key;
+    const cardIndex = markerID - 1;
 
     let x = markerID * CARD_WIDTH + markerID * 20;
     if (Platform.OS === "ios") {
@@ -434,11 +428,20 @@ const [state, setState] = useState({
   const _map = useRef(null);
   const _scrollView = useRef(null);
 
+  if (!state.region) {
+    return ExploreLoadingScreen;
+  }
+
   return (
     <View style={styles.container}>
       <MapView
         ref={_map}
-        initialRegion={state.region}
+        initialRegion={{
+          latitude: state.region.latitude,
+          longitude: state.region.longitude,
+          latitudeDelta: state.region.latitudeDelta,
+          longitudeDelta: state.region.longitudeDelta,
+        }}
         style={styles.container}
         provider={PROVIDER_GOOGLE}
         customMapStyle={isDarkmode ? mapDarkStyle : mapStandardStyle}

--- a/lib/screens/mapPage/ExploreScreen.js
+++ b/lib/screens/mapPage/ExploreScreen.js
@@ -21,7 +21,6 @@ import ApiService from "../../utils/api_calls";
 import Constants from 'expo-constants';
 import { Keyboard } from 'react-native';
 import { useTheme } from '../../components/ThemeProvider';
-import ExploreLoadingScreen from "./ExploreLoadingScreen";
 
 const { width } = Dimensions.get("window");
 const CARD_HEIGHT = 220;
@@ -36,7 +35,7 @@ const ExploreScreen = () => {
   const [mapType, setMapType] = useState('standard'); // New state for map type
   const { theme, isDarkmode } = useTheme();
   const [showMapTypeOptions, setShowMapTypeOptions] = useState(false);
-  
+
   const toggleMapTypeOptions = () => {
     setShowMapTypeOptions(prevState => !prevState);
   };
@@ -87,10 +86,18 @@ const ExploreScreen = () => {
         globeIcon !== "earth",
         "someUserId"
       );
-
-      console.log("STEP 3: fetchedNotes from ApiService.fetchMessages:", fetchedNotes);
-      // console.log("Notes being used: ", fetchedNotes);
-
+  
+      // console.log("STEP 3: fetchedNotes from ApiService.fetchMessages:", fetchedNotes);
+      
+      // Write the count to the log file
+      await RNFS.appendFile(logFilePath, `Count of fetched notes: ${fetchedNotes.length}\n`, 'utf8')
+        .then(() => {
+          console.log('Logged count to file');
+        })
+        .catch(err => {
+          console.error('Error writing to log file:', err);
+        });
+  
       const fetchedMarkers = fetchedNotes.map((note) => {
         let time;
         if (note.time === undefined) {
@@ -101,7 +108,7 @@ const ExploreScreen = () => {
         } else {
           time = new Date(note.time);
         }
-
+  
         return {
           coordinate: {
             latitude: parseFloat(note.latitude) || 0,
@@ -113,20 +120,22 @@ const ExploreScreen = () => {
           description: note.BodyText || "",
           images:
             note.media.map((mediaItem) => ({ uri: mediaItem.uri })) ||
-            require("../../../assets/map_marker.png"), // need to replace with placeholder image
+            require("../../../assets/map_marker.png"), // Placeholder image replacement
           time: formatToLocalDateString(time) || "",
           tags: note.tags || [],
         };
       });
-
+  
       setState((prevState) => ({
         ...prevState,
         markers: fetchedMarkers,
+        notesCount: fetchedNotes.length, // if you need to use this count in your state
       }));
     } catch (error) {
       console.error("Error fetching messages:", error);
     }
   });
+  
 
   useEffect(() => {
     fetchMessages();
@@ -274,96 +283,62 @@ const ExploreScreen = () => {
     },
   });
 
-  const [state, setState] = useState({
-    markers: [],
-    categories: [
-      {
-        name: "Events",
-        icon: (
-          <MaterialCommunityIcons
-            style={styles.chipsIcon}
-            name="calendar-multiple"
-            size={18}
-          />
-        ),
-      },
-      {
-        name: "Cultural",
-        icon: (
-          <Ionicons
-            name="ios-globe-outline"
-            style={styles.chipsIcon}
-            size={18}
-          />
-        ),
-      },
-      {
-        name: "History",
-        icon: <Ionicons name="md-time" style={styles.chipsIcon} size={18} />,
-      },
-      {
-        name: "Modern",
-        icon: (
-          <MaterialCommunityIcons
-            name="city-variant-outline"
-            style={styles.chipsIcon}
-            size={18}
-          />
-        ),
-      },
-      {
-        name: "Religious",
-        icon: (
-          <MaterialCommunityIcons
-            name="church"
-            style={styles.chipsIcon}
-            size={15}
-          />
-        ),
-      },
-    ],
-    region: null
-  });
+const [state, setState] = useState({
+  markers: [],
+  categories: [
+    {
+      name: "Events",
+      icon: (
+        <MaterialCommunityIcons
+          style={styles.chipsIcon}
+          name="calendar-multiple"
+          size={18}
+        />
+      ),
+    },
+    {
+      name: "Cultural",
+      icon: (
+        <Ionicons
+          name="ios-globe-outline"
+          style={styles.chipsIcon}
+          size={18}
+        />
+      ),
+    },
+    {
+      name: "History",
+      icon: <Ionicons name="md-time" style={styles.chipsIcon} size={18} />,
+    },
+    {
+      name: "Modern",
+      icon: (
+        <MaterialCommunityIcons
+          name="city-variant-outline"
+          style={styles.chipsIcon}
+          size={18}
+        />
+      ),
+    },
+    {
+      name: "Religious",
+      icon: (
+        <MaterialCommunityIcons
+          name="church"
+          style={styles.chipsIcon}
+          size={15}
+        />
+      ),
+    },
+  ],
+  region: {
+    latitude: 38.631393,
+    longitude: -90.192226,
+    latitudeDelta: 0.04864195044303443,
+    longitudeDelta: 0.040142817690068,
+  },
+});
 
-  useEffect(() => {
-    let isMounted = true;
-  
-    (async () => {
-      let { status } = await Location.requestForegroundPermissionsAsync();
-      if (status !== "granted") {
-        Alert.alert(
-          "Permission Denied",
-          "Permission to access location was denied. This is required on this page",
-          [{
-            text: "Try Again",
-            onPress: () => {
-              (async () => {
-                await Location.requestForegroundPermissionsAsync();
-              })();
-            }
-          }]
-        );
-        return; // Early return to avoid executing further code without permission
-      }
-  
-      let location = await Location.getCurrentPositionAsync({});
-      const { latitude, longitude } = location.coords;
-      if (isMounted) {
-        setState(prevState => ({
-          ...prevState,
-          region: {
-            latitude,
-            longitude,
-            latitudeDelta: 0.058370340531641314,
-            longitudeDelta: 0.0481713812280816,
-          }
-        }));
-      }
-    })();
-  
-    return () => isMounted = false;
-  }, []);
-  
   let mapIndex = 0;
   let mapAnimation = new Animated.Value(0);
 
@@ -394,7 +369,49 @@ const ExploreScreen = () => {
         }
       }, 10);
     });
-  });  
+  });
+
+  useEffect(() => {
+    let isMounted = true;
+  
+    (async () => {
+      let { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== "granted") {
+        Alert.alert(
+          "Permission Denied",
+          "Permission to access location was denied. This is required on this page",
+          [
+            {
+              text: "Try Again",
+              onPress: () => {
+                (async () => {
+                  await Location.requestForegroundPermissionsAsync();
+                })();
+              }
+            },
+          ]
+        );
+        return; // Early return to avoid executing further code without permission
+      }
+  
+      let location = await Location.getCurrentPositionAsync({});
+      const { latitude, longitude } = location.coords;
+      if (isMounted) {
+        setState(prevState => ({
+          ...prevState,
+          region: {
+            latitude,
+            longitude,
+            latitudeDelta: 0.04864195044303443,
+            longitudeDelta: 0.040142817690068,
+          }
+        }));
+      }
+    })();
+  
+    return () => isMounted = false;
+  }, []);
+  
 
   const interpolations = state.markers.map((marker, index) => {
     const inputRange = [
@@ -414,7 +431,6 @@ const ExploreScreen = () => {
 
   const onMarkerPress = (mapEventData) => {
     const markerID = mapEventData._targetInst.return.key;
-    const cardIndex = markerID - 1;
 
     let x = markerID * CARD_WIDTH + markerID * 20;
     if (Platform.OS === "ios") {
@@ -427,20 +443,11 @@ const ExploreScreen = () => {
   const _map = useRef(null);
   const _scrollView = useRef(null);
 
-  if (!state.region) {
-    return <ExploreLoadingScreen />;
-  }
-
   return (
     <View style={styles.container}>
       <MapView
         ref={_map}
-        initialRegion={{
-          latitude: state.region.latitude,
-          longitude: state.region.longitude,
-          latitudeDelta: state.region.latitudeDelta,
-          longitudeDelta: state.region.longitudeDelta,
-        }}
+        initialRegion={state.region}
         style={styles.container}
         provider={PROVIDER_GOOGLE}
         customMapStyle={isDarkmode ? mapDarkStyle : mapStandardStyle}
@@ -493,7 +500,7 @@ const ExploreScreen = () => {
       <View style={styles.searchBox}>
       <TouchableOpacity onPress={() => {
           setGlobeIcon(prevIcon => (prevIcon === "earth-outline" ? "earth" : "earth-outline"));
-          setSearchResults(null); 
+          setSearchResults(null);
       }}>
           <Ionicons 
               name={globeIcon} 

--- a/lib/screens/mapPage/ExploreScreen.js
+++ b/lib/screens/mapPage/ExploreScreen.js
@@ -429,7 +429,7 @@ const ExploreScreen = () => {
   const _scrollView = useRef(null);
 
   if (!state.region) {
-    return ExploreLoadingScreen;
+    return <ExploreLoadingScreen />;
   }
 
   return (


### PR DESCRIPTION
Fixes #144 

What was changed?

For this pull request, the files that were changed were the ExploreScreen and I also added a ExploreLoadingScreen

Why was it changed?

One thing we were requested to add for this issue was to add loading the ExploreScreen based on the location of the User. This is because by default the ExploreScreen started at St. Louis. Now because it starts based on the location of the user, it will be more relevant to the user when they first open up the screen. However, one thing that should be changed because of this is that cards should be based on proximity of the user. 

How was it changed?

So a useEffect was used to grab the user's location and then the latitude and longitude were changed to match the user's location. Additionally, an ExploreLoadingScreen was added so now the LoadingScreen shows first on initial render to allow for the useEffect to grab location first!

Screenshots that show the changes (if applicable):