### PR TITLE
video insertion now works on the Add Notes screen

### DIFF
--- a/__tests__/AddNoteScreen.test.tsx
+++ b/__tests__/AddNoteScreen.test.tsx
@@ -63,6 +63,14 @@ describe('AddNoteScreen', () => {
     expect(getByTestId('RichEditor')).toBeTruthy();
   });
 
+  it('renders the save button', () => {
+    const routeMock = { params: { untitledNumber: 1 } };
+    const { getByTestId } = render(<AddNoteScreen route={routeMock as any} />);
+
+    // Check if the save button is rendered
+    expect(getByTestId('checklocationpermission')).toBeTruthy();
+  });
+
 
   it('handles saveNote API error', async () => {
     const routeMock = { params: { untitledNumber: 1 } };
@@ -141,7 +149,6 @@ describe("AddNoteScreen's checkLocationPermission method", () => {
     await waitFor(() => {
       expect(mockWriteNewNote).toHaveBeenCalledTimes(0); // Adjust expected to 0
     });
-  });
-  
+  });  
   
 });

--- a/lib/screens/AddNoteScreen.tsx
+++ b/lib/screens/AddNoteScreen.tsx
@@ -90,18 +90,20 @@ const AddNoteScreen: React.FC<{ navigation: any, route: any }> = ({ navigation, 
 
   const addVideoToEditor = async (videoUri: string) => {
     try {
-      const thumbnailUri = await getThumbnail(videoUri);
-      const videoTag = `
-        <video width="320" height="240" controls poster="${thumbnailUri}">
-          <source src="${videoUri}" type="video/mp4">
-          Your browser does not support the video tag.
-        </video>`;
-      editor.commands.setContent(editor.getHTML() + videoTag);
+      // Append the video to the existing content
+      editor.setImage(videoUri);
+  
+      editor.injectCSS(`
+        video {
+          width: 100px !important;
+          height: 100px !important;
+        }
+      `);
     } catch (error) {
-      console.error("Error adding video: ", error);
+      console.error("Error adding video:", error);
     }
   };
-
+  
   const insertAudioToEditor = (audioUri: string) => {
     const audioTag = `<audio controls src="${audioUri}"></audio>`;
     editor.commands.setContent(editor.getHTML() + audioTag);

--- a/lib/screens/AddNoteScreen.tsx
+++ b/lib/screens/AddNoteScreen.tsx
@@ -53,9 +53,9 @@ const AddNoteScreen: React.FC<{ navigation: any, route: any }> = ({ navigation, 
 
   // Add a guard check before calling editor.commands.focus()
   useEffect(() => {
-    if (editor?.commands?.focus) {
+    if (editor?.focus) {
       const timeout = setTimeout(() => {
-        editor.commands.focus();
+        editor.focus();
       }, 500);
       return () => clearTimeout(timeout);
     }
@@ -90,15 +90,19 @@ const AddNoteScreen: React.FC<{ navigation: any, route: any }> = ({ navigation, 
 
   const addVideoToEditor = async (videoUri: string) => {
     try {
-      // Append the video to the existing content
-      editor.setImage(videoUri);
+      // Get the current HTML content in the editor
+      const currentHTML = await editor.getHTML();
   
-      editor.injectCSS(`
-        video {
-          width: 100px !important;
-          height: 100px !important;
-        }
-      `);
+      // Construct the video HTML tag with full width and block-level display
+      const videoTag = `
+        <div style="width: 100%; display: block; margin-bottom: 16px;">
+          <img src="${videoUri}" style="width: 100%; height: auto;" />
+        </div>
+      `;
+  
+      // Insert the video tag into the editor content with a newline after it
+      editor.setContent(currentHTML + videoTag + '<p><br/></p>');  // Ensure text after video starts on a new line
+  
     } catch (error) {
       console.error("Error adding video:", error);
     }


### PR DESCRIPTION
Fixes #186 

**What was changed**
The result of this PR is that it allows users to insert videos into their notes on the Add Notes screen. This results in a positive and enjoyable user experience.

**Why was it changed**
Currently, the "Add Notes" page does not allow users to attach videos to their notes, causing a poor user experience. With this change, users will be able to attach videos to notes, giving the user more flexibility and usability of the notes feature. Important to note that the Rich Text Editor was migrated to 10Tap. So this change was necessary for the videos to be able to be attached to notes.

**How was it changed**
In the ```addVideoToEditor```, ```editor.setImage()``` function was used to insert a video into the notes. ```editor.injectCSS()``` was used to inject css styling to the video to make it 100px by 100px.

**UI after changes**
<img width="378" alt="image" src="https://github.com/user-attachments/assets/ce9499df-6abb-434d-8492-35865cb741a4">
