### PR TITLE
Search bar toggle functionality

### DIFF
--- a/__tests__/HomeScreen.test.tsx
+++ b/__tests__/HomeScreen.test.tsx
@@ -50,3 +50,4 @@ describe('HomeScreen', () => {
   });
 
 });
+

--- a/__tests__/HomeScreen.test.tsx
+++ b/__tests__/HomeScreen.test.tsx
@@ -41,12 +41,23 @@ afterEach(() => {
 });
 
 describe('HomeScreen', () => {
-  it('renders without crashing', () => {
+  it('renders toggle search bar', async () => {
     const routeMock = { params: { untitledNumber: 1 } };
     const { getByTestId } = render(<HomeScreen route={routeMock as any} />);
+  
+    const toggleButton = await waitFor(() => getByTestId('searchButton'));
+    expect(toggleButton).toBeTruthy();
+  });
 
-    // Check if the RichEditor is rendered
-    expect(getByTestId('searchBar')).toBeTruthy();
+  it('toggle search bar visibility', async () => {
+    const routeMock = { params: { untitledNumber: 1 } };
+    const { getByTestId } = render(<HomeScreen route={routeMock as any} />);
+  
+    const toggleButton = await waitFor(() => getByTestId('searchButton'));
+    fireEvent.press(toggleButton);
+  
+    const searchBar = await waitFor(() => getByTestId('searchBar'));
+    expect(searchBar).toBeTruthy();
   });
 
 });

--- a/__tests__/__snapshots__/MoreScreen.test.tsx.snap
+++ b/__tests__/__snapshots__/MoreScreen.test.tsx.snap
@@ -4,23 +4,33 @@ exports[`MorePage renders correctly 1`] = `
 [
   <View
     style={
-      {
-        "alignItems": "center",
-        "backgroundColor": "#ffffff",
-        "justifyContent": "center",
-        "marginBottom": -8,
-        "marginTop": 53.36,
-        "padding": 13.34,
-      }
+      [
+        {
+          "alignItems": "center",
+          "backgroundColor": "#ffffff",
+          "justifyContent": "center",
+          "marginBottom": -8,
+          "marginTop": 53.36,
+          "padding": 13.34,
+        },
+        {
+          "backgroundColor": undefined,
+        },
+      ]
     }
   >
     <Text
       style={
-        {
-          "color": "#000000",
-          "fontSize": 32,
-          "fontWeight": "bold",
-        }
+        [
+          {
+            "color": "#000000",
+            "fontSize": 32,
+            "fontWeight": "bold",
+          },
+          {
+            "color": "#000000",
+          },
+        ]
       }
     >
       Where's Religion
@@ -60,12 +70,17 @@ exports[`MorePage renders correctly 1`] = `
         <View>
           <Text
             style={
-              {
-                "alignSelf": "center",
-                "color": "#000000",
-                "fontSize": 28,
-                "fontWeight": "bold",
-              }
+              [
+                {
+                  "alignSelf": "center",
+                  "color": "#000000",
+                  "fontSize": 28,
+                  "fontWeight": "bold",
+                },
+                {
+                  "color": "#000000",
+                },
+              ]
             }
           >
             Resources
@@ -106,12 +121,17 @@ exports[`MorePage renders correctly 1`] = `
           >
             <Text
               style={
-                {
-                  "alignSelf": "center",
-                  "color": "#000000",
-                  "fontSize": 16,
-                  "lineHeight": 28,
-                }
+                [
+                  {
+                    "alignSelf": "center",
+                    "color": "#000000",
+                    "fontSize": 16,
+                    "lineHeight": 28,
+                  },
+                  {
+                    "color": "#000000",
+                  },
+                ]
               }
             >
               Our Website
@@ -153,12 +173,17 @@ exports[`MorePage renders correctly 1`] = `
           >
             <Text
               style={
-                {
-                  "alignSelf": "center",
-                  "color": "#000000",
-                  "fontSize": 16,
-                  "lineHeight": 28,
-                }
+                [
+                  {
+                    "alignSelf": "center",
+                    "color": "#000000",
+                    "fontSize": 16,
+                    "lineHeight": 28,
+                  },
+                  {
+                    "color": "#000000",
+                  },
+                ]
               }
             >
               Guide to Ethnography
@@ -200,12 +225,17 @@ exports[`MorePage renders correctly 1`] = `
           >
             <Text
               style={
-                {
-                  "alignSelf": "center",
-                  "color": "#000000",
-                  "fontSize": 16,
-                  "lineHeight": 28,
-                }
+                [
+                  {
+                    "alignSelf": "center",
+                    "color": "#000000",
+                    "fontSize": 16,
+                    "lineHeight": 28,
+                  },
+                  {
+                    "color": "#000000",
+                  },
+                ]
               }
             >
               Guide to Coding
@@ -247,12 +277,17 @@ exports[`MorePage renders correctly 1`] = `
           >
             <Text
               style={
-                {
-                  "alignSelf": "center",
-                  "color": "#000000",
-                  "fontSize": 16,
-                  "lineHeight": 28,
-                }
+                [
+                  {
+                    "alignSelf": "center",
+                    "color": "#000000",
+                    "fontSize": 16,
+                    "lineHeight": 28,
+                  },
+                  {
+                    "color": "#000000",
+                  },
+                ]
               }
             >
               Report a Bug
@@ -260,48 +295,68 @@ exports[`MorePage renders correctly 1`] = `
           </View>
           <Text
             style={
-              {
-                "alignSelf": "center",
-                "color": "#000000",
-                "fontSize": 28,
-                "fontWeight": "bold",
-              }
+              [
+                {
+                  "alignSelf": "center",
+                  "color": "#000000",
+                  "fontSize": 28,
+                  "fontWeight": "bold",
+                },
+                {
+                  "color": "#000000",
+                },
+              ]
             }
           >
             Meet our Team
           </Text>
           <Text
             style={
-              {
-                "alignSelf": "center",
-                "color": "#000000",
-                "fontSize": 16,
-                "lineHeight": 28,
-              }
+              [
+                {
+                  "alignSelf": "center",
+                  "color": "#000000",
+                  "fontSize": 16,
+                  "lineHeight": 28,
+                },
+                {
+                  "color": "#000000",
+                },
+              ]
             }
           >
             Insert Team Photo
           </Text>
           <Text
             style={
-              {
-                "alignSelf": "center",
-                "color": "#000000",
-                "fontSize": 16,
-                "lineHeight": 28,
-              }
+              [
+                {
+                  "alignSelf": "center",
+                  "color": "#000000",
+                  "fontSize": 16,
+                  "lineHeight": 28,
+                },
+                {
+                  "color": "#000000",
+                },
+              ]
             }
           >
             Insert Team Message
           </Text>
           <Text
             style={
-              {
-                "alignSelf": "center",
-                "color": "#000000",
-                "fontSize": 28,
-                "fontWeight": "bold",
-              }
+              [
+                {
+                  "alignSelf": "center",
+                  "color": "#000000",
+                  "fontSize": 28,
+                  "fontWeight": "bold",
+                },
+                {
+                  "color": "#000000",
+                },
+              ]
             }
           >
             Frequently Asked Questions
@@ -309,120 +364,170 @@ exports[`MorePage renders correctly 1`] = `
         </View>
         <Text
           style={
-            {
-              "alignSelf": "center",
-              "color": "#000000",
-              "fontSize": 28,
-              "fontWeight": "bold",
-            }
+            [
+              {
+                "alignSelf": "center",
+                "color": "#000000",
+                "fontSize": 28,
+                "fontWeight": "bold",
+              },
+              {
+                "color": "#000000",
+              },
+            ]
           }
         >
           What can users do?
         </Text>
         <Text
           style={
-            {
-              "alignSelf": "center",
-              "color": "#000000",
-              "fontSize": 16,
-              "lineHeight": 28,
-            }
+            [
+              {
+                "alignSelf": "center",
+                "color": "#000000",
+                "fontSize": 16,
+                "lineHeight": 28,
+              },
+              {
+                "color": "#000000",
+              },
+            ]
           }
         >
           Explore religious traditions, find places of worship, engage in meaningful discussions.
         </Text>
         <Text
           style={
-            {
-              "alignSelf": "center",
-              "color": "#000000",
-              "fontSize": 28,
-              "fontWeight": "bold",
-            }
+            [
+              {
+                "alignSelf": "center",
+                "color": "#000000",
+                "fontSize": 28,
+                "fontWeight": "bold",
+              },
+              {
+                "color": "#000000",
+              },
+            ]
           }
         >
           Who is it for?
         </Text>
         <Text
           style={
-            {
-              "alignSelf": "center",
-              "color": "#000000",
-              "fontSize": 16,
-              "lineHeight": 28,
-            }
+            [
+              {
+                "alignSelf": "center",
+                "color": "#000000",
+                "fontSize": 16,
+                "lineHeight": 28,
+              },
+              {
+                "color": "#000000",
+              },
+            ]
           }
         >
           Scholars, students, believers, and the curious about the world's religions.
         </Text>
         <Text
           style={
-            {
-              "alignSelf": "center",
-              "color": "#000000",
-              "fontSize": 28,
-              "fontWeight": "bold",
-            }
+            [
+              {
+                "alignSelf": "center",
+                "color": "#000000",
+                "fontSize": 28,
+                "fontWeight": "bold",
+              },
+              {
+                "color": "#000000",
+              },
+            ]
           }
         >
           What's unique?
         </Text>
         <Text
           style={
-            {
-              "alignSelf": "center",
-              "color": "#000000",
-              "fontSize": 16,
-              "lineHeight": 28,
-            }
+            [
+              {
+                "alignSelf": "center",
+                "color": "#000000",
+                "fontSize": 16,
+                "lineHeight": 28,
+              },
+              {
+                "color": "#000000",
+              },
+            ]
           }
         >
           Provides a modern method to capture experiences using the devices that are with us every day.
         </Text>
         <Text
           style={
-            {
-              "alignSelf": "center",
-              "color": "#000000",
-              "fontSize": 28,
-              "fontWeight": "bold",
-            }
+            [
+              {
+                "alignSelf": "center",
+                "color": "#000000",
+                "fontSize": 28,
+                "fontWeight": "bold",
+              },
+              {
+                "color": "#000000",
+              },
+            ]
           }
         >
           Our Mission
         </Text>
         <Text
           style={
-            {
-              "alignSelf": "center",
-              "color": "#000000",
-              "fontSize": 16,
-              "lineHeight": 28,
-            }
+            [
+              {
+                "alignSelf": "center",
+                "color": "#000000",
+                "fontSize": 16,
+                "lineHeight": 28,
+              },
+              {
+                "color": "#000000",
+              },
+            ]
           }
         >
           Connect people of diverse religious backgrounds, beliefs, and practices.
         </Text>
         <Text
           style={
-            {
-              "alignSelf": "center",
-              "color": "#000000",
-              "fontSize": 28,
-              "fontWeight": "bold",
-            }
+            [
+              {
+                "alignSelf": "center",
+                "color": "#000000",
+                "fontSize": 28,
+                "fontWeight": "bold",
+              },
+              {
+                "color": "#000000",
+              },
+            ]
           }
         >
           Why use 'Where's Religion?'
         </Text>
         <Text
           style={
-            {
-              "alignSelf": "center",
-              "color": "#000000",
-              "fontSize": 16,
-              "lineHeight": 28,
-            }
+            [
+              {
+                "alignSelf": "center",
+                "color": "#000000",
+                "fontSize": 16,
+                "lineHeight": 28,
+              },
+              {
+                "color": "#000000",
+              },
+            ]
           }
         >
           Explore religious traditions, find places of worship, engage in meaningful discussions.
@@ -445,25 +550,35 @@ exports[`MorePage renders correctly 1`] = `
           >
             <View
               style={
-                {
-                  "alignItems": "center",
-                  "backgroundColor": "#f0f0f0",
-                  "borderRadius": 10,
-                  "flexDirection": "row",
-                  "justifyContent": "space-between",
-                  "padding": 6,
-                  "width": "94%",
-                }
+                [
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#f0f0f0",
+                    "borderRadius": 10,
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "padding": 6,
+                    "width": "94%",
+                  },
+                  {
+                    "backgroundColor": undefined,
+                  },
+                ]
               }
             >
               <Text
                 style={
-                  {
-                    "color": "#000000",
-                    "fontSize": 18,
-                    "fontWeight": "500",
-                    "marginLeft": 9,
-                  }
+                  [
+                    {
+                      "color": "#000000",
+                      "fontSize": 18,
+                      "fontWeight": "500",
+                      "marginLeft": 9,
+                    },
+                    {
+                      "color": "#000000",
+                    },
+                  ]
                 }
               >
                 Dark Mode
@@ -490,11 +605,16 @@ exports[`MorePage renders correctly 1`] = `
         </View>
         <View
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "width": "100%",
-            }
+            [
+              {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "width": "100%",
+              },
+              {
+                "backgroundColor": undefined,
+              },
+            ]
           }
         >
           <View
@@ -528,7 +648,7 @@ exports[`MorePage renders correctly 1`] = `
             style={
               {
                 "alignItems": "center",
-                "backgroundColor": "#ff0000",
+                "backgroundColor": "black",
                 "borderRadius": 15,
                 "flexDirection": "row",
                 "height": 50,
@@ -542,13 +662,18 @@ exports[`MorePage renders correctly 1`] = `
           >
             <Text
               style={
-                {
-                  "color": "#ffffff",
-                  "fontSize": 20,
-                  "fontWeight": "600",
-                  "marginLeft": 5,
-                  "marginRight": 10,
-                }
+                [
+                  {
+                    "color": "#ffffff",
+                    "fontSize": 20,
+                    "fontWeight": "600",
+                    "marginLeft": 5,
+                    "marginRight": 10,
+                  },
+                  {
+                    "color": "white",
+                  },
+                ]
               }
             >
               Logout

--- a/__tests__/__snapshots__/SetTime.test.tsx.snap
+++ b/__tests__/__snapshots__/SetTime.test.tsx.snap
@@ -38,8 +38,8 @@ exports[`LocationWindow renders without crashing 1`] = `
           }
         }
       >
-        10/8/2024
-11:33 PM
+        10/27/2024
+01:29 PM
       </Text>
     </View>
     <View

--- a/lib/screens/HomeScreen.tsx
+++ b/lib/screens/HomeScreen.tsx
@@ -597,6 +597,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation, route }) => {
           <Image source={require('../../assets/icon.png')} style={{width: width * 0.105, height: width * 0.105, marginEnd: width * 0.025}} />
           <TouchableOpacity onPress={() => setIsSearchVisible(!isSearchVisible)}>
             <Ionicons
+              testID="searchButton"
               name={isSearchVisible ? "close-outline" : "search-outline"} // Switch between "X" and search icon
               size={36}
               color={theme.text}

--- a/lib/screens/HomeScreen.tsx
+++ b/lib/screens/HomeScreen.tsx
@@ -50,6 +50,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation, route }) => {
   const [selectedNote, setSelectedNote] = useState<Note | undefined>(undefined);
   const [isModalVisible, setModalVisible] = useState(false);
   const [isSearchVisible, setIsSearchVisible] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
 
   const { theme } = useTheme();
 
@@ -539,12 +540,10 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation, route }) => {
     );
   };
 
-  //Part of searchbar:
-  const [searchQuery, setSearchQuery] = useState("");
-
   const handleSearch = (query: string) => {
     setSearchQuery(query);
   };
+
   const formatDate = (date: Date) => {
     const day = date.getDate().toString();
     const month = (date.getMonth() + 1).toString(); // Months are zero-based
@@ -562,10 +561,14 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation, route }) => {
     });
   }, [notes, searchQuery]);
 
-
+  // Reset search query when toggling search visibility
+  const resetSearchQuery = () => {
+    if(isSearchVisible){
+      setSearchQuery('');
+    }
+  };
 
   return (
- 
     <View style={styles.container}>
       <View style={styles.topView}>
         <View
@@ -590,12 +593,17 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation, route }) => {
             <Text style={styles.pfpText}>{userInitials}</Text>
           </TouchableOpacity>
           <Image source={require('../../assets/icon.png')} style={{width: width * 0.105, height: width * 0.105, marginEnd: width * 0.025}} />
-          <TouchableOpacity onPress={() => setIsSearchVisible(!isSearchVisible)}>
+          <TouchableOpacity 
+            onPress={() => {
+              setIsSearchVisible(!isSearchVisible);
+              resetSearchQuery(); // Reset search query when toggling search visibility              
+            }}
+          >
             <Ionicons
               testID="searchButton"
               name={isSearchVisible ? "close-outline" : "search-outline"} // Switch between "X" and search icon
               size={36}
-              color={theme.text}
+              color={theme.black}
             />
           </TouchableOpacity>
         </View>

--- a/lib/screens/HomeScreen.tsx
+++ b/lib/screens/HomeScreen.tsx
@@ -49,6 +49,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation, route }) => {
   const [items, setItems] = useState(initialItems);
   const [selectedNote, setSelectedNote] = useState<Note | undefined>(undefined);
   const [isModalVisible, setModalVisible] = useState(false);
+  const [isSearchVisible, setIsSearchVisible] = useState(false);
 
   const { theme } = useTheme();
 
@@ -161,6 +162,10 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation, route }) => {
     });
     return maxNumber + 1;
   };
+
+  const toggleSearchBar = () => {
+    setIsSearchVisible(!isSearchVisible);
+};
   
 
   const styles = StyleSheet.create({
@@ -332,7 +337,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation, route }) => {
       padding: 10,
       alignSelf: "center",
     },
-    seachBar:{
+    searchBar:{
       backgroundColor: theme.homeColor,
       borderRadius: 20,
       fontSize: 18,
@@ -589,7 +594,14 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation, route }) => {
           >
             <Text style={styles.pfpText}>{userInitials}</Text>
           </TouchableOpacity>
-          <Image source={require('../../assets/icon.png')} style={{width: width * 0.105, height: width * 0.105, marginEnd: width * 0.435}} />
+          <Image source={require('../../assets/icon.png')} style={{width: width * 0.105, height: width * 0.105, marginEnd: width * 0.025}} />
+          <TouchableOpacity onPress={() => setIsSearchVisible(!isSearchVisible)}>
+            <Ionicons
+              name={isSearchVisible ? "close-outline" : "search-outline"} // Switch between "X" and search icon
+              size={36}
+              color={theme.text}
+            />
+          </TouchableOpacity>
         </View>
       </View>
        
@@ -634,12 +646,15 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation, route }) => {
           showArrowIcon={true}
         /> 
       </View>
+      {isSearchVisible && (
       <TextInput
-          testID="searchBar"
-          placeholder="Search notes.."
-          onChangeText={handleSearch}
-          style= {styles.seachBar}
+        testID="searchBar"
+        placeholder="Search notes..."
+        onChangeText={handleSearch}
+        style={styles.searchBar}
         />
+      )}
+
       <View style={styles.horizontalLine} />
       <View style={styles.scrollerBackgroundColor}>
         {rendering ? <NoteSkeleton /> : renderList(notes)}

--- a/lib/screens/HomeScreen.tsx
+++ b/lib/screens/HomeScreen.tsx
@@ -163,11 +163,6 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation, route }) => {
     return maxNumber + 1;
   };
 
-  const toggleSearchBar = () => {
-    setIsSearchVisible(!isSearchVisible);
-};
-  
-
   const styles = StyleSheet.create({
     container: {
       paddingTop: Constants.statusBarHeight - 20,


### PR DESCRIPTION
Fixes #191 

**What was changed**
This pull request modifies the search bar functionality so that it is only available when toggled by clicking the search icon. Once the search icon is clicked, the search bar appears; clicking the icon again hides the search bar.

**Why was it changed**
Previously, the search bar was permanently fixed in the header, taking up space when it is not needed, which lead to a poor user experience. By making the search bar toggled by a search icon, we keep the interface cleaner and simpler, leading to an improved user experience. 

**How was it changed**
To implement the changes, I made a few code changes. First, I added a state variable for the search bar, ```isSearchVisible``` by using the ```useState``` hook. I added a ```TouchableOpacity``` icon which when pressed would set the ```isSearchVisible``` to ```true``` or ```false``` depending on whether the search bar should be available or not. I then added conditional rendering for the search bar. Lastly, I implemented an "X" icon when the search bar was toggled, and a search icon when it was not toggled.