### PR TITLE
Loading screen on photo delay

### DIFF
--- a/__mocks__/@react-native-async-storage/NativeAnimatedHelper.js
+++ b/__mocks__/@react-native-async-storage/NativeAnimatedHelper.js
@@ -1,0 +1,2 @@
+// __mocks__/NativeAnimatedHelper.js
+module.exports = {};

--- a/__tests__/NoteDetailModal.test.tsx
+++ b/__tests__/NoteDetailModal.test.tsx
@@ -1,10 +1,33 @@
+// __tests__/NoteDetailModal.test.tsx
+
+import 'react-native'; // required for react-native testing
+
+// --- Mock Animated Easing ---
+// This mock prevents errors like "_bezier is not a function" by returning dummy easing functions.
+jest.mock('react-native/Libraries/Animated/Easing', () => ({
+  linear: (t: number) => t,
+  ease: (t: number) => t,
+  in: (t: number) => t,
+  out: (t: number) => t,
+  inOut: (t: number) => t,
+  bezier: () => (t: number) => t,
+}));
+
+// Note: The NativeAnimatedHelper mapping is configured in your jest.config.js via moduleNameMapper.
+// For example, in your jest.config.js you should have:
+// moduleNameMapper: {
+//   '^react-native/Libraries/Animated/NativeAnimatedHelper$': '<rootDir>/__mocks__/NativeAnimatedHelper.js',
+// },
+
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import NoteDetailModal from '../lib/screens/mapPage/NoteDetailModal';
-import moxios = require('moxios');
+import moxios from 'moxios';
 import { onAuthStateChanged } from 'firebase/auth';
+import ApiService from '../lib/utils/api_calls';
 
-// Mock ThemeProvider
+// --- Mocks for ThemeProvider and Firebase services ---
+
 jest.mock('../lib/components/ThemeProvider', () => ({
   useTheme: () => ({
     theme: {
@@ -14,7 +37,6 @@ jest.mock('../lib/components/ThemeProvider', () => ({
   }),
 }));
 
-// Mock Firebase services
 jest.mock("firebase/app", () => ({
   initializeApp: jest.fn(),
 }));
@@ -25,7 +47,6 @@ jest.mock("firebase/auth", () => ({
   getReactNativePersistence: jest.fn(),
   onAuthStateChanged: jest.fn(), // Mock onAuthStateChanged
 }));
-
 
 jest.mock("firebase/firestore", () => ({
   getFirestore: jest.fn(),
@@ -49,7 +70,6 @@ jest.mock('react-native/Libraries/Image/Image', () => ({
   resolveAssetSource: jest.fn(() => ({ uri: 'mocked-asset-uri' })),
 }));
 
-
 jest.mock('react-native/Libraries/Settings/NativeSettingsManager', () => ({
   settings: {},
   setValues: jest.fn(),
@@ -63,18 +83,17 @@ onAuthStateChanged.mockImplementation((auth, callback) => {
   callback(mockUser); // Simulate a logged-in user
 });
 
-
-// Save the original console methods to call later
+// Save original console methods so we can restore them after tests
 const originalConsoleError = console.error;
 const originalConsoleLog = console.log;
 
 beforeEach(() => {
-  // Mock console.warn to silence specific warnings
+  // Silence console logs/warnings during tests
   jest.spyOn(console, 'log').mockImplementation(() => {});
   jest.spyOn(console, 'error').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
   
-  moxios.install()
+  moxios.install();
 });
 
 afterEach(() => {
@@ -82,20 +101,19 @@ afterEach(() => {
   console.error.mockRestore();
   console.warn.mockRestore();
   moxios.uninstall();
-
 });
 
 describe('NoteDetailModal', () => {
   const mockNote = {
     title: 'Test Note Title',
-    description: '<div><img src="https://example.com/image1.jpg" alt="Test Image" /></div>'
-      + '<div><a href="https://example.com/video.mp4">Video</a></div>',
+    description:
+      '<div><img src="https://example.com/image1.jpg" alt="Test Image" /></div>' +
+      '<div><a href="https://example.com/video.mp4">Video</a></div>',
     creator: 'https://api.example.com/user/1',
     time: '2023-09-10',
     tags: ['test-tag-1', 'test-tag-2'],
     images: [{ uri: 'https://example.com/image1.jpg' }],
   };
-  
 
   it('renders without crashing', () => {
     const { toJSON } = render(
@@ -104,21 +122,17 @@ describe('NoteDetailModal', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
+  // Uncomment these tests to verify button interactions:
+  
   it('should respond to image button press', () => {
     const { getByTestId } = render(
       <NoteDetailModal isVisible={true} note={mockNote} onClose={() => {}} />
     );
 
-    // Find the image button by testID
+    // Find the image button by testID (from your LoadingImage component)
     const imageButton = getByTestId('imageButton');
-
-    // Ensure the button exists
     expect(imageButton).toBeTruthy();
-
-    // Simulate the button press
     fireEvent.press(imageButton);
-
-    // Additional assertions if needed
   });
 
   it('should respond to video button press', () => {
@@ -128,15 +142,27 @@ describe('NoteDetailModal', () => {
 
     // Find the video button by testID
     const videoButton = getByTestId('videoButton');
-
-    // Ensure the button exists
     expect(videoButton).toBeTruthy();
-
-    // Simulate the button press
     fireEvent.press(videoButton);
-
-    // Additional assertions if needed
   });
 
-
+  it('should render static loading dots when creator name is loading', () => {
+    // Mock the fetchCreatorName function to return a promise that never resolves.
+    const fetchCreatorNameSpy = jest
+      .spyOn(ApiService, 'fetchCreatorName')
+      .mockReturnValue(new Promise(() => {})); // never resolves
+  
+    const { getByTestId } = render(
+      <NoteDetailModal isVisible={true} note={mockNote} onClose={() => {}} />
+    );
+  
+    // Since the promise never resolves, creatorName stays empty,
+    // and your component renders <LoadingDots /> which in test mode returns static text.
+    expect(getByTestId('loadingDotsStatic')).toBeTruthy();
+  
+    // Restore the spy after the test.
+    fetchCreatorNameSpy.mockRestore();
+  });
+  
+  
 });

--- a/__tests__/NoteDetailModal.test.tsx
+++ b/__tests__/NoteDetailModal.test.tsx
@@ -1,6 +1,11 @@
-// __tests__/NoteDetailModal.test.tsx
 
 import 'react-native'; 
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import NoteDetailModal from '../lib/screens/mapPage/NoteDetailModal';
+import moxios from 'moxios';
+import { onAuthStateChanged } from 'firebase/auth';
+import ApiService from '../lib/utils/api_calls';
 
 jest.mock('react-native/Libraries/Animated/Easing', () => ({
   linear: (t: number) => t,
@@ -10,13 +15,6 @@ jest.mock('react-native/Libraries/Animated/Easing', () => ({
   inOut: (t: number) => t,
   bezier: () => (t: number) => t,
 }));
-
-import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
-import NoteDetailModal from '../lib/screens/mapPage/NoteDetailModal';
-import moxios from 'moxios';
-import { onAuthStateChanged } from 'firebase/auth';
-import ApiService from '../lib/utils/api_calls';
 
 jest.mock('../lib/components/ThemeProvider', () => ({
   useTheme: () => ({
@@ -161,4 +159,11 @@ describe('NoteDetailModal', () => {
     expect(getByTestId('no-image')).toBeTruthy();
     expect(getByText("Couldn't load image")).toBeTruthy();
   });
+  it('should display loading indicator while image is loading', () => {
+    const { getByTestId } = render(
+      <NoteDetailModal isVisible={true} note={mockNote} onClose={() => {}} />
+    );
+    expect(getByTestId('loadingIndicator')).toBeTruthy();
+  });
+  
 });

--- a/__tests__/NoteDetailModal.test.tsx
+++ b/__tests__/NoteDetailModal.test.tsx
@@ -1,9 +1,7 @@
 // __tests__/NoteDetailModal.test.tsx
 
-import 'react-native'; // required for react-native testing
+import 'react-native'; 
 
-// --- Mock Animated Easing ---
-// This mock prevents errors like "_bezier is not a function" by returning dummy easing functions.
 jest.mock('react-native/Libraries/Animated/Easing', () => ({
   linear: (t: number) => t,
   ease: (t: number) => t,
@@ -13,20 +11,12 @@ jest.mock('react-native/Libraries/Animated/Easing', () => ({
   bezier: () => (t: number) => t,
 }));
 
-// Note: The NativeAnimatedHelper mapping is configured in your jest.config.js via moduleNameMapper.
-// For example, in your jest.config.js you should have:
-// moduleNameMapper: {
-//   '^react-native/Libraries/Animated/NativeAnimatedHelper$': '<rootDir>/__mocks__/NativeAnimatedHelper.js',
-// },
-
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import NoteDetailModal from '../lib/screens/mapPage/NoteDetailModal';
 import moxios from 'moxios';
 import { onAuthStateChanged } from 'firebase/auth';
 import ApiService from '../lib/utils/api_calls';
-
-// --- Mocks for ThemeProvider and Firebase services ---
 
 jest.mock('../lib/components/ThemeProvider', () => ({
   useTheme: () => ({
@@ -83,7 +73,6 @@ onAuthStateChanged.mockImplementation((auth, callback) => {
   callback(mockUser); // Simulate a logged-in user
 });
 
-// Save original console methods so we can restore them after tests
 const originalConsoleError = console.error;
 const originalConsoleLog = console.log;
 
@@ -167,15 +156,9 @@ describe('NoteDetailModal', () => {
       <NoteDetailModal isVisible={true} note={mockNote} onClose={() => {}} />
     );
     
-    // Fire an error event on the image so that the component sets error state.
     fireEvent(getByTestId('bufferingImage'), 'error');
   
-    // Check that the error view is displayed by looking for its testID or text.
     expect(getByTestId('no-image')).toBeTruthy();
     expect(getByText("Couldn't load image")).toBeTruthy();
   });
-  
-  
-  
-  
 });

--- a/__tests__/NoteDetailModal.test.tsx
+++ b/__tests__/NoteDetailModal.test.tsx
@@ -137,4 +137,6 @@ describe('NoteDetailModal', () => {
 
     // Additional assertions if needed
   });
+
+
 });

--- a/__tests__/NoteDetailModal.test.tsx
+++ b/__tests__/NoteDetailModal.test.tsx
@@ -163,6 +163,20 @@ describe('NoteDetailModal', () => {
     // Restore the spy after the test.
     fetchCreatorNameSpy.mockRestore();
   });
+  it('should display error message if image fails to load', () => {
+    const { getByTestId, getByText } = render(
+      <NoteDetailModal isVisible={true} note={mockNote} onClose={() => {}} />
+    );
+    
+    // Fire an error event on the image so that the component sets error state.
+    fireEvent(getByTestId('bufferingImage'), 'error');
+  
+    // Check that the error view is displayed by looking for its testID or text.
+    expect(getByTestId('no-image')).toBeTruthy();
+    expect(getByText("Couldn't load image")).toBeTruthy();
+  });
+  
+  
   
   
 });

--- a/__tests__/NoteDetailModal.test.tsx
+++ b/__tests__/NoteDetailModal.test.tsx
@@ -164,6 +164,37 @@ describe('NoteDetailModal', () => {
       <NoteDetailModal isVisible={true} note={mockNote} onClose={() => {}} />
     );
     expect(getByTestId('loadingIndicator')).toBeTruthy();
+  }); it('should display video loading indicator while video thumbnail is loading', () => {
+    // Create a note with a video link in the description.
+    const videoNote = {
+      ...mockNote,
+      description: '<div><a href="https://example.com/video.mp4">Video</a></div>',
+    };
+
+    const { getByTestId } = render(
+      <NoteDetailModal isVisible={true} note={videoNote} onClose={() => {}} />
+    );
+    expect(getByTestId('videoLoadingIndicator')).toBeTruthy();
   });
+
+  it('should display audio loading indicator while audio is loading', () => {
+    jest.useFakeTimers();
+    const audioNote = {
+      ...mockNote,
+      description: '<div><a href="https://example.com/audio.mp3">Audio</a></div>',
+    };
+  
+    const expoAV = require('expo-av');
+    jest.spyOn(expoAV.Audio.Sound, 'createAsync').mockReturnValue(new Promise(() => {}));
+  
+    const { getByTestId } = render(
+      <NoteDetailModal isVisible={true} note={audioNote} onClose={() => {}} />
+    );
+    
+    expect(getByTestId('audioLoadingIndicator')).toBeTruthy();
+    jest.useRealTimers();
+  });
+  
+
   
 });

--- a/__tests__/NoteDetailModal.test.tsx
+++ b/__tests__/NoteDetailModal.test.tsx
@@ -122,7 +122,6 @@ describe('NoteDetailModal', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  // Uncomment these tests to verify button interactions:
   
   it('should respond to image button press', () => {
     const { getByTestId } = render(

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,7 @@ module.exports = {
   transformIgnorePatterns: [
     'node_modules/(?!react-native|@react-native|expo|@expo|@unimodules)' // Ensure proper transformation of React Native modules
   ],
+  moduleNameMapper: {
+    '^react-native/Libraries/Animated/NativeAnimatedHelper$': '<rootDir>/__mocks__/NativeAnimatedHelper.js',
+  },
 };

--- a/lib/screens/mapPage/NoteDetailModal.tsx
+++ b/lib/screens/mapPage/NoteDetailModal.tsx
@@ -147,11 +147,6 @@ const LoadingVideoButton: React.FC<LoadingVideoButtonProps> = ({ uri, onPress })
 };
 
 
-// LoadingAudio Component
-// Displays an ActivityIndicator while loading the audio file.
-// If the audio fails to load, displays an error icon and message.
-// Once loaded, it shows a simple play button UI (for demonstration).
-
 // LoadingDots Component
 // If tests are running, simply render static text.
 // Otherwise, run the animated dots sequence.
@@ -483,7 +478,6 @@ const NoteDetailModal: React.FC<NoteDetailModalProps> = memo(({ isVisible, onClo
           setIsPlaying(false);
         } else {
           const status = await sound.getStatusAsync();
-          // Restart from beginning if audio has finished.
           if (status.positionMillis >= status.durationMillis) {
             await sound.setPositionAsync(0);
           }
@@ -545,7 +539,6 @@ const NoteDetailModal: React.FC<NoteDetailModalProps> = memo(({ isVisible, onClo
     );
   };
   
-
   return (
     <Modal animationType="slide" transparent={false} visible={isVisible}>
       <TouchableOpacity onPress={onClose} style={styles.closeButton}>

--- a/lib/screens/mapPage/NoteDetailModal.tsx
+++ b/lib/screens/mapPage/NoteDetailModal.tsx
@@ -21,10 +21,10 @@ import VideoModal from "./VideoModal";
 import { Audio } from "expo-av";
 import { VideoType } from "../../models/media_class";
 
-// ---------------------------------------
+//
 // LoadingImage Component
 // Displays an ActivityIndicator overlay until the image loads
-// ---------------------------------------
+//
 interface LoadingImageProps {
   uri: string;
   alt?: string;
@@ -80,15 +80,14 @@ const loadingImageStyles = StyleSheet.create({
   },
 });
 
-// ---------------------------------------
+//
 // LoadingDots Component
-// Displays animated blinking dots (using the Animated API)
-// while waiting for the creator name to load
-// ---------------------------------------
+// Displays three animated dots using the Animated API.
+//
 const LoadingDots: React.FC = () => {
-  const dot1Opacity = useRef(new Animated.Value(0)).current;
-  const dot2Opacity = useRef(new Animated.Value(0)).current;
-  const dot3Opacity = useRef(new Animated.Value(0)).current;
+  const dot1Opacity = useRef(new Animated.Value(15)).current;
+  const dot2Opacity = useRef(new Animated.Value(15)).current;
+  const dot3Opacity = useRef(new Animated.Value(15)).current;
 
   useEffect(() => {
     const animateDots = () => {
@@ -124,7 +123,7 @@ const LoadingDots: React.FC = () => {
           duration: 300,
           useNativeDriver: true,
         }),
-        Animated.delay(300),
+        Animated.delay(100),
       ]).start(() => animateDots());
     };
 
@@ -133,7 +132,6 @@ const LoadingDots: React.FC = () => {
 
   return (
     <View style={loadingDotsStyles.container}>
-      <Text style={loadingDotsStyles.text}>Loading</Text>
       <Animated.Text style={[loadingDotsStyles.dot, { opacity: dot1Opacity }]}>
         .
       </Animated.Text>
@@ -152,20 +150,16 @@ const loadingDotsStyles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
   },
-  text: {
-    fontSize: 18,
-    color: "#333",
-  },
   dot: {
     fontSize: 18,
     color: "#333",
-    marginLeft: 2,
+    marginHorizontal: 2,
   },
 });
 
-// ---------------------------------------
+//
 // NoteDetailModal Component
-// ---------------------------------------
+//
 interface Note {
   title: string;
   description: string;
@@ -189,7 +183,7 @@ const NoteDetailModal: React.FC<NoteDetailModalProps> = memo(({ isVisible, onClo
   const { width } = useWindowDimensions();
   const { theme } = useTheme();
 
-  // Reset state on note change to avoid flashing previous note content.
+  // Reset internal state on note change to avoid flashing previous note data.
   useEffect(() => {
     setCreatorName("");
     setSelectedImage(null);
@@ -249,10 +243,7 @@ const NoteDetailModal: React.FC<NoteDetailModalProps> = memo(({ isVisible, onClo
         await audioState.sound.pauseAsync();
         setAudioStates((prev) => ({
           ...prev,
-          [uri]: {
-            ...audioState,
-            isPlaying: false,
-          },
+          [uri]: { ...audioState, isPlaying: false },
         }));
         setPlayingMedia(null);
       } else {
@@ -309,7 +300,7 @@ const NoteDetailModal: React.FC<NoteDetailModalProps> = memo(({ isVisible, onClo
     return `${mins}:${secs}`;
   };
 
-  // Updated customRenderers using LoadingImage for <img> tags
+  // Custom renderers for RenderHTML
   const customRenderers = useMemo(() => ({
     img: ({ tnode }: TNodeRendererProps<any>) => {
       const { src, alt } = tnode.attributes;

--- a/lib/screens/mapPage/NoteDetailModal.tsx
+++ b/lib/screens/mapPage/NoteDetailModal.tsx
@@ -22,11 +22,10 @@ import VideoModal from "./VideoModal";
 import { Audio } from "expo-av";
 import { VideoType } from "../../models/media_class";
 
-//
+
 // LoadingImage Component
 // Displays an ActivityIndicator overlay until the image loads.
 // If the image fails to load, it displays an error icon and message.
-//
 interface LoadingImageProps {
   uri: string;
   alt?: string;
@@ -99,11 +98,10 @@ const loadingImageStyles = StyleSheet.create({
   },
 });
 
-//
+
 // LoadingVideoButton Component
 // Displays an ActivityIndicator overlay while attempting to load the video thumbnail.
 // If the thumbnail fails to load, it shows an error icon and message.
-//
 interface LoadingVideoButtonProps {
   uri: string;
   onPress: (video: VideoType) => void;
@@ -148,12 +146,12 @@ const LoadingVideoButton: React.FC<LoadingVideoButtonProps> = ({ uri, onPress })
   );
 };
 
-//
+
 // LoadingAudio Component
 // Displays an ActivityIndicator while loading the audio file.
 // If the audio fails to load, displays an error icon and message.
 // Once loaded, it shows a simple play button UI (for demonstration).
-//
+
 const LoadingAudio: React.FC<{ uri: string }> = ({ uri }) => {
   const { theme } = useTheme();
   const [loading, setLoading] = useState(true);
@@ -210,7 +208,7 @@ const LoadingAudio: React.FC<{ uri: string }> = ({ uri }) => {
   );
 };
 
-//
+
 // LoadingDots Component
 // If tests are running, simply render static text.
 // Otherwise, run the animated dots sequence.
@@ -292,9 +290,9 @@ const loadingDotsStyles = StyleSheet.create({
   },
 });
 
-//
+
 // NoteDetailModal Component
-//
+
 interface Note {
   title: string;
   description: string;

--- a/lib/screens/mapPage/NoteDetailModal.tsx
+++ b/lib/screens/mapPage/NoteDetailModal.tsx
@@ -1,3 +1,4 @@
+// NoteDetailModal.tsx
 import React, { useState, useEffect, memo, useMemo, useRef } from "react";
 import {
   Modal,
@@ -37,11 +38,11 @@ const LoadingImage: React.FC<LoadingImageProps> = ({ uri, alt, onPress }) => {
   return (
     <View style={loadingImageStyles.container}>
       <Image
+        testID="bufferingImage"
         source={{ uri }}
         style={[loadingImageStyles.image, { opacity: loading ? 0 : 1 }]}
         accessibilityLabel={alt}
         onLoadEnd={() => setLoading(false)}
-        testID="bufferingImage"
       />
       {loading && (
         <View style={loadingImageStyles.loadingOverlay}>
@@ -49,6 +50,7 @@ const LoadingImage: React.FC<LoadingImageProps> = ({ uri, alt, onPress }) => {
         </View>
       )}
       <TouchableOpacity
+        testID="imageButton"
         style={StyleSheet.absoluteFill}
         onPress={() => onPress(uri)}
       />
@@ -83,12 +85,18 @@ const loadingImageStyles = StyleSheet.create({
 
 //
 // LoadingDots Component
-// Displays three animated dots using the Animated API.
+// If tests are running, simply render static text.
+// Otherwise, run the animated dots sequence.
 //
 const LoadingDots: React.FC = () => {
-  const dot1Opacity = useRef(new Animated.Value(15)).current;
-  const dot2Opacity = useRef(new Animated.Value(15)).current;
-  const dot3Opacity = useRef(new Animated.Value(15)).current;
+  // If in test mode, return a static placeholder to avoid animation errors.
+  if (!!process.env.JEST_WORKER_ID) {
+    return <Text testID="loadingDotsStatic">...</Text>;
+  }
+
+  const dot1Opacity = useRef(new Animated.Value(0)).current;
+  const dot2Opacity = useRef(new Animated.Value(0)).current;
+  const dot3Opacity = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
     const animateDots = () => {
@@ -124,7 +132,7 @@ const LoadingDots: React.FC = () => {
           duration: 300,
           useNativeDriver: true,
         }),
-        Animated.delay(100),
+        Animated.delay(300),
       ]).start(() => animateDots());
     };
 

--- a/lib/screens/mapPage/NoteDetailModal.tsx
+++ b/lib/screens/mapPage/NoteDetailModal.tsx
@@ -1,3 +1,4 @@
+// NoteDetailModal.tsx
 import React, { useState, useEffect, memo, useMemo, useRef } from "react";
 import {
   Modal,
@@ -21,10 +22,11 @@ import VideoModal from "./VideoModal";
 import { Audio } from "expo-av";
 import { VideoType } from "../../models/media_class";
 
-
+//
 // LoadingImage Component
 // Displays an ActivityIndicator overlay until the image loads.
-
+// If the image fails to load, it displays an error icon and message.
+//
 interface LoadingImageProps {
   uri: string;
   alt?: string;
@@ -32,13 +34,14 @@ interface LoadingImageProps {
 }
 
 const LoadingImage: React.FC<LoadingImageProps> = ({ uri, alt, onPress }) => {
+  const { theme } = useTheme();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 
   if (error) {
     return (
       <View testID="no-image" style={loadingImageStyles.container}>
-        <Ionicons name="alert-circle-outline" size={50} color="#ff0000" />
+        <Ionicons name="alert-circle-outline" size={50} color={theme.homeColor} />
         <Text style={styles.errorText}>Couldn't load image</Text>
       </View>
     );
@@ -59,7 +62,7 @@ const LoadingImage: React.FC<LoadingImageProps> = ({ uri, alt, onPress }) => {
       />
       {loading && (
         <View style={loadingImageStyles.loadingOverlay}>
-          <ActivityIndicator testID="loadingIndicator" size="large" color="#0000ff" />
+          <ActivityIndicator testID="loadingIndicator" size="large" color={theme.homeColor} />
         </View>
       )}
       <TouchableOpacity
@@ -96,22 +99,25 @@ const loadingImageStyles = StyleSheet.create({
   },
 });
 
+//
 // LoadingVideoButton Component
 // Displays an ActivityIndicator overlay while attempting to load the video thumbnail.
-
+// If the thumbnail fails to load, it shows an error icon and message.
+//
 interface LoadingVideoButtonProps {
   uri: string;
   onPress: (video: VideoType) => void;
 }
 
 const LoadingVideoButton: React.FC<LoadingVideoButtonProps> = ({ uri, onPress }) => {
+  const { theme } = useTheme();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 
   if (error) {
     return (
       <View style={[loadingImageStyles.container, { width: 400, height: 400 / 1.77 }]}>
-        <Ionicons name="alert-circle-outline" size={50} color="#ff0000" />
+        <Ionicons name="alert-circle-outline" size={50} color={theme.homeColor} />
         <Text style={styles.errorText}>Couldn't load video</Text>
       </View>
     );
@@ -130,7 +136,7 @@ const LoadingVideoButton: React.FC<LoadingVideoButtonProps> = ({ uri, onPress })
       />
       {loading && (
         <View style={loadingImageStyles.loadingOverlay}>
-          <ActivityIndicator size="large" color="#0000ff" />
+          <ActivityIndicator testID="videoLoadingIndicator" size="large" color={theme.homeColor} />
         </View>
       )}
       <TouchableOpacity
@@ -142,10 +148,12 @@ const LoadingVideoButton: React.FC<LoadingVideoButtonProps> = ({ uri, onPress })
   );
 };
 
-
+//
 // LoadingAudio Component
 // Displays an ActivityIndicator while loading the audio file.
 // If the audio fails to load, displays an error icon and message.
+// Once loaded, it shows a simple play button UI (for demonstration).
+//
 const LoadingAudio: React.FC<{ uri: string }> = ({ uri }) => {
   const { theme } = useTheme();
   const [loading, setLoading] = useState(true);
@@ -178,7 +186,7 @@ const LoadingAudio: React.FC<{ uri: string }> = ({ uri }) => {
   if (error) {
     return (
       <View style={styles.audioContainer}>
-        <Ionicons name="alert-circle-outline" size={30} color="#ff0000" />
+        <Ionicons name="alert-circle-outline" size={30} color={theme.homeColor} />
         <Text style={styles.errorText}>Couldn't load audio</Text>
       </View>
     );
@@ -187,7 +195,7 @@ const LoadingAudio: React.FC<{ uri: string }> = ({ uri }) => {
   if (loading) {
     return (
       <View style={styles.audioContainer}>
-        <ActivityIndicator size="large" color={theme.primaryColor} />
+        <ActivityIndicator testID="audioLoadingIndicator" size="large" color={theme.homeColor} />
       </View>
     );
   }
@@ -202,14 +210,14 @@ const LoadingAudio: React.FC<{ uri: string }> = ({ uri }) => {
   );
 };
 
-
+//
 // LoadingDots Component
 // If tests are running, simply render static text.
 // Otherwise, run the animated dots sequence.
-
 const LoadingDots: React.FC = () => {
+  const { theme } = useTheme();
   if (!!process.env.JEST_WORKER_ID) {
-    return <Text testID="loadingDotsStatic">...</Text>;
+    return <Text testID="loadingDotsStatic" style={{ color: theme.homeColor }}>...</Text>;
   }
 
   const dot1Opacity = useRef(new Animated.Value(0)).current;
@@ -279,12 +287,14 @@ const loadingDotsStyles = StyleSheet.create({
   },
   dot: {
     fontSize: 18,
-    color: "#333",
+    color: "#333", // This will be overridden by theme.homeColor in our component.
     marginHorizontal: 2,
   },
 });
 
-
+//
+// NoteDetailModal Component
+//
 interface Note {
   title: string;
   description: string;

--- a/lib/screens/mapPage/NoteDetailModal.tsx
+++ b/lib/screens/mapPage/NoteDetailModal.tsx
@@ -98,11 +98,11 @@ const loadingImageStyles = StyleSheet.create({
   },
 });
 
-//
+
 // LoadingVideoButton Component
 // Displays an ActivityIndicator overlay while attempting to load the video thumbnail.
 // If the thumbnail fails to load, it shows an error icon and message.
-//
+
 interface LoadingVideoButtonProps {
   uri: string;
   onPress: (video: VideoType) => void;
@@ -146,11 +146,10 @@ const LoadingVideoButton: React.FC<LoadingVideoButtonProps> = ({ uri, onPress })
   );
 };
 
-//
 // LoadingDots Component
 // If tests are running, simply render static text.
 // Otherwise, run the animated dots sequence.
-//
+
 const LoadingDots: React.FC = () => {
   if (!!process.env.JEST_WORKER_ID) {
     return <Text testID="loadingDotsStatic">...</Text>;
@@ -228,9 +227,8 @@ const loadingDotsStyles = StyleSheet.create({
   },
 });
 
-//
 // NoteDetailModal Component
-//
+
 interface Note {
   title: string;
   description: string;

--- a/lib/screens/mapPage/NoteDetailModal.tsx
+++ b/lib/screens/mapPage/NoteDetailModal.tsx
@@ -167,7 +167,7 @@ interface LoadingImageProps {
 const LoadingImage: React.FC<LoadingImageProps> = ({ uri, alt, onPress }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
-  const theme = useTheme();
+  const { theme } = useTheme();
 
   if (error) {
     return (
@@ -193,7 +193,7 @@ const LoadingImage: React.FC<LoadingImageProps> = ({ uri, alt, onPress }) => {
           setError(true);
         }}
       />
-      {loading && (
+        {loading && (
         <View style={loadingImageStyles.loadingOverlay}>
           <ActivityIndicator testID="loadingIndicator" size="large" color={theme.homeColor} />
         </View>
@@ -209,8 +209,8 @@ const LoadingImage: React.FC<LoadingImageProps> = ({ uri, alt, onPress }) => {
 
 const loadingImageStyles = StyleSheet.create({
   container: {
-    width: 400, 
-    height: 400, 
+    width: 400, // adjust as needed
+    height: 400, // adjust as needed
     position: "relative",
     justifyContent: "center",
     alignItems: "center",
@@ -316,7 +316,7 @@ const loadingDotsStyles = StyleSheet.create({
   },
   dot: {
     fontSize: 18,
-    color: "#333",
+    color: "333",
     marginHorizontal: 2,
   },
 });
@@ -332,7 +332,7 @@ const LoadingVideo: React.FC<LoadingVideoProps> = ({ uri, onPress, width }) => {
   const [error, setError] = useState(false);
   const containerWidth = width - 40;
   const containerHeight = containerWidth / 1.77;
-  const theme = useTheme();
+  const {theme} = useTheme();
 
   if (error) {
     return (
@@ -397,7 +397,6 @@ const loadingVideoStyles = StyleSheet.create({
     bottom: 0,
     justifyContent: "center",
     alignItems: "center",
-    backgroundColor: "rgba(255,255,255,0.7)",
   },
   errorContainer: {
     flex: 1,
@@ -407,7 +406,7 @@ const loadingVideoStyles = StyleSheet.create({
   },
   errorText: {
     marginTop: 10,
-    color: "white",
+    color: "red",
     fontSize: 16,
   },
 });

--- a/lib/screens/mapPage/NoteDetailModal.tsx
+++ b/lib/screens/mapPage/NoteDetailModal.tsx
@@ -22,11 +22,11 @@ import VideoModal from "./VideoModal";
 import { Audio } from "expo-av";
 import { VideoType } from "../../models/media_class";
 
-//
+
 // LoadingImage Component
 // Displays an ActivityIndicator overlay until the image loads.
 // If the image fails to load, it displays an error icon and message.
-//
+
 interface LoadingImageProps {
   uri: string;
   alt?: string;

--- a/lib/screens/mapPage/NoteDetailModal.tsx
+++ b/lib/screens/mapPage/NoteDetailModal.tsx
@@ -41,10 +41,11 @@ const LoadingImage: React.FC<LoadingImageProps> = ({ uri, alt, onPress }) => {
         style={[loadingImageStyles.image, { opacity: loading ? 0 : 1 }]}
         accessibilityLabel={alt}
         onLoadEnd={() => setLoading(false)}
+        testID="bufferingImage"
       />
       {loading && (
         <View style={loadingImageStyles.loadingOverlay}>
-          <ActivityIndicator size="large" color="#0000ff" />
+          <ActivityIndicator testID="loadingIndicator" size="large" color="#0000ff" />
         </View>
       )}
       <TouchableOpacity

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/moxios": "^0.4.17",
     "@types/react-native-fetch-blob": "^0.10.11",
     "@types/react-native-onboarding-swiper": "^1.1.9",
-    "axios": "^1.7.2",
+    "axios": "^1.7.9",
     "babel-plugin-transform-inline-environment-variables": "^0.4.4",
     "cheerio": "0.22.0",
     "enzyme": "^3.11.0",


### PR DESCRIPTION
Fixes #218 

What was changed
-When viewing a note the image sometimes would load in a bit later now a loading symbol is put where that photo will show up so the user knows content is loading. This is also for videos. Also the username would be that of a prior note for a split second that has now been changed to be 3 animated dots until the actual user appears. 

-error message when content cannot load
Why was it changed:
- To improve UI by indicating that content is still loading and prevent displaying stale content.

How was it changed:
- Implemented a LoadingImage component with an ActivityIndicator overlay. This is used in conjunction with some useStates to know when things are still being loaded. And these variables are used as conditionals. 
- Updated the creator display to show animated dots (fallback to static in tests) until data is fetched.
-detects and error and returns different JSX if so, hard to test visually so test case was provided.

https://github.com/user-attachments/assets/f489548a-f048-44a1-a442-6a7348db1547

