### PR TITLE
Fix Issue #223

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,3 +1,5 @@
+import 'react-native-gesture-handler';
+import 'react-native-reanimated';
 import React, { useState, useEffect } from 'react';
 import AppNavigator from './lib/navigation/AppNavigator';
 import { LogBox } from 'react-native';
@@ -6,8 +8,7 @@ import Toast from 'react-native-toast-message';
 import { Provider } from 'react-redux';
 import { store, persistor } from './redux/store/store';
 import { AddNoteProvider } from './lib/context/AddNoteContext';
-import 'react-native-gesture-handler';
-import { PersistGate } from 'redux-persist/lib/integration/react'; 
+import { PersistGate } from 'redux-persist/lib/integration/react';
 
 
 export default function App() {

--- a/lib/components/ThemeProvider.js
+++ b/lib/components/ThemeProvider.js
@@ -16,10 +16,18 @@ export function ThemeProvider({ children }) {
   const [isDarkmode, setIsDarkmode] = useState(false);
   colors.darkColors.homeColor = appThemeColor;
   colors.lightColors.homeColor = appThemeColor;
+
+  // function to update the theme color dynamically
+  const updateThemeColor = (newColor) => {
+    colors.darkColors.homeColor = newColor;
+    colors.lightColors.homeColor = newColor;
+    AsyncStorage.save('appThemeColor', newColor)
+  };
+
   console.log(colors.darkColors.homeColor, appThemeColor)
+
   const toggleDarkmode = () => {
     setIsDarkmode((prevMode) => !prevMode);
-
     // Save the theme preference in AsyncStorage
     AsyncStorage.save('themePreference', !isDarkmode ? 'dark' : 'light');
   };
@@ -33,6 +41,16 @@ export function ThemeProvider({ children }) {
       .catch((error) => {
         console.error('Error loading theme preference:', error);
       });
+
+    AsyncStorage.get('appThemeColor')
+    .then((storedColor) => {
+      if (storedColor) {
+        updateThemeColor(storedColor);
+      }
+    })
+        .catch((error) => {
+          console.error('Error loading custom theme color: ', error);
+        });
   }, []);
 
   const theme = isDarkmode ? colors.darkColors : colors.lightColors;

--- a/lib/screens/AppThemeSelectorScreen.tsx
+++ b/lib/screens/AppThemeSelectorScreen.tsx
@@ -2,10 +2,9 @@ import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Modal } from 'react-native';
 import { useTheme } from '../components/ThemeProvider';
 import { appTheme } from '../components/colors';
-import { useDispatch, UseDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { themeReducer } from '../../redux/slice/ThemeSlice';
-
-import ColorWheel from 'react-native-wheel-color-picker';
+import { ColorPicker } from 'react-native-color-picker';
 
 function AppThemeSelectorScreen() {
 
@@ -13,27 +12,18 @@ function AppThemeSelectorScreen() {
     const { theme, updateThemeColor } = useTheme();
     const [colorPickerVisible, setColorPickerVisible] = useState(false);
     const [selectedColor, setSelectedColor] = useState(theme.homeColor);
-    // const [selectedColor, setSelectedColor] = useState('#ff0000'); // Default color
-    // const [sliderValue, setSliderValue] = useState(0.5); // Slider value state
 
-    const handleColorSelected = (color) => {
-        setSelectedColor(color);
-        updateThemeColor(color);
+    const handleConfirmColor = () => {
+        updateThemeColor(selectedColor);              // Context
+        dispatch(themeReducer(selectedColor));        // Redux
         setColorPickerVisible(false);
-    }
-    // const handleColorChange = (color) => {
-    //     console.log('Selected Color:', color);
-    //     setSelectedColor(color);
-    // };
+    };
 
     return (
         <View style={styles.container}>
-
             <Text style={[styles.currentThemeTxt, { color: 'green' }]}>Current Theme</Text>
-
             {/** Theme Box */}
-            <View
-                style={[
+            <View style={[
                     styles.themeContainer,
                     {
                         backgroundColor: theme.homeColor,
@@ -72,17 +62,17 @@ function AppThemeSelectorScreen() {
             >
                 <View style={styles.colorPickerContainer}>
                     <Text style={styles.modalTitle}>Pick a Color</Text>
-                    <ColorWheel
-                        initialColor={selectedColor}
-                        onColorChangeComplete={(color) => setSelectedColor(color)}
+                    <ColorPicker
+                        onColorChange={setSelectedColor}
                         style={styles.colorWheel}
-                        thumbStyle={{ borderWidth: 2, borderColor: '#fff'}}
                     />
+
                     <TouchableOpacity onPress={handleConfirmColor} style={styles.confirmButton}>
                         <Text style={styles.buttonText}>Confirm</Text>
                     </TouchableOpacity>
-                    <TouchableOpacity onPress={() => setColorPickerVisible(false)}
-                                      style={styles.closeButton}
+                    <TouchableOpacity
+                        onPress={() => setColorPickerVisible(false)}
+                        style={styles.closeButton}
                     >
                         <Text style={styles.closeButtonText}>Cancel</Text>
                     </TouchableOpacity>
@@ -125,6 +115,14 @@ const styles = StyleSheet.create({
         justifyContent: 'center',
         alignItems: 'center',
     },
+    modalTitle: {
+        fontSize: 20,
+        marginBottom: 20
+    },
+    colorWheel: {
+        width: '90%',
+        height: 300
+    },
     colorPicker: {
         width: '90%',
         height: 30,
@@ -145,5 +143,15 @@ const styles = StyleSheet.create({
         borderRadius: 25,
         alignSelf: 'center',
         marginTop: 20,
+    },
+    buttonText: {
+        color: '#fff',
+        fontSize: 16,
+    },
+    confirmButton: {
+        marginTop: 20,
+        padding: 10,
+        backgroundColor: '#007AFF',
+        borderRadius: 5,
     },
 });

--- a/lib/screens/AppThemeSelectorScreen.tsx
+++ b/lib/screens/AppThemeSelectorScreen.tsx
@@ -1,18 +1,26 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { View, Text, StyleSheet, TouchableOpacity, Modal } from 'react-native';
 import { useTheme } from '../components/ThemeProvider';
 import { appTheme } from '../components/colors';
 import { useDispatch, UseDispatch } from 'react-redux';
 import { themeReducer } from '../../redux/slice/ThemeSlice';
 
+import ColorWheel from 'react-native-wheel-color-picker';
+
 function AppThemeSelectorScreen() {
 
     const dispatch = useDispatch();
-    const { theme, isDarkmode } = useTheme();
+    const { theme, updateThemeColor } = useTheme();
+    const [colorPickerVisible, setColorPickerVisible] = useState(false);
+    const [selectedColor, setSelectedColor] = useState(theme.homeColor);
     // const [selectedColor, setSelectedColor] = useState('#ff0000'); // Default color
     // const [sliderValue, setSliderValue] = useState(0.5); // Slider value state
 
+    const handleColorSelected = (color) => {
+        setSelectedColor(color);
+        updateThemeColor(color);
+        setColorPickerVisible(false);
+    }
     // const handleColorChange = (color) => {
     //     console.log('Selected Color:', color);
     //     setSelectedColor(color);
@@ -24,16 +32,23 @@ function AppThemeSelectorScreen() {
             <Text style={[styles.currentThemeTxt, { color: 'green' }]}>Current Theme</Text>
 
             {/** Theme Box */}
-            <View style={[styles.themeContainer, {
-                backgroundColor: theme.homeColor, height: 40,
-                width: 80,
-                borderRadius: 30,
-            }]}></View>
+            <View
+                style={[
+                    styles.themeContainer,
+                    {
+                        backgroundColor: theme.homeColor,
+                        height: 40,
+                        width: 80,
+                        borderRadius: 30,
+                    },
+                ]}
+            />
 
             <View style={styles.ThemeSection}>
                 {
                     appTheme.map((theme, key) => (
-                        <TouchableOpacity key={key} 
+                        <TouchableOpacity
+                            key={key}
                             onPress={() => {
                                 dispatch(themeReducer(theme.themeColor))
                             }}
@@ -42,17 +57,39 @@ function AppThemeSelectorScreen() {
                         </TouchableOpacity>
                     ))
                 }
-                <TouchableOpacity>
+                <TouchableOpacity onPress={() => setColorPickerVisible(true)}>
                     <View style={[styles.themeContainer, { backgroundColor: '#a3a3a3', justifyContent: 'center', alignItems: 'center' }]}>
                         <Text style={{ fontSize: 35, }}>+</Text>
                     </View>
                 </TouchableOpacity>
             </View>
 
-            
-          
+            <Modal
+                visible={colorPickerVisible}
+                animationType="slide"
+                transparent={false}
+                onRequestClose={() => setColorPickerVisible(false)}
+            >
+                <View style={styles.colorPickerContainer}>
+                    <Text style={styles.modalTitle}>Pick a Color</Text>
+                    <ColorWheel
+                        initialColor={selectedColor}
+                        onColorChangeComplete={(color) => setSelectedColor(color)}
+                        style={styles.colorWheel}
+                        thumbStyle={{ borderWidth: 2, borderColor: '#fff'}}
+                    />
+                    <TouchableOpacity onPress={handleConfirmColor} style={styles.confirmButton}>
+                        <Text style={styles.buttonText}>Confirm</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity onPress={() => setColorPickerVisible(false)}
+                                      style={styles.closeButton}
+                    >
+                        <Text style={styles.closeButtonText}>Cancel</Text>
+                    </TouchableOpacity>
+                </View>
+            </Modal>
         </View>
-    )
+    );
 }
 
 export default AppThemeSelectorScreen;
@@ -89,12 +126,18 @@ const styles = StyleSheet.create({
         alignItems: 'center',
     },
     colorPicker: {
-        width: '100%',
-        height: 200,
+        width: '90%',
+        height: 30,
     },
-    slider: {
-        width: '100%',
-        height: 40,
+    closeButton: {
+        width: '90%',
+        backgroundColor: '#ccc',
+        marginTop: 20,
+        borderRadius: 5,
+    },
+    closeButtonText: {
+        fontSize: 15,
+        color: '#333',
     },
     selectedColorPreview: {
         height: 50,


### PR DESCRIPTION
Fixes Issue #223: Integrate color picker for apptheme option in settings (more page)

this PR works on customizing the app's theme color.
CHANGES:
themeprovider
- added an updateThemeColor function to dynamically update and persist the app's theme color
AppeThemeSelectorScreen
- removed the react-native-color picker that also relied on the Slider API and replaced it with react-native-color-wheel
- updated modal logic to display color wheel and confirm color selection
- maintained existing UI elements (+ button, predefined theme swatches)

WHY:
- previous library used a removed slider and react native core, causing runtime errors
- enhancing theme customization to improve the user personalization
- react-native-color-wheel tries to avoid any dependency issue, and might provide a cleaner solution but needs to be checked if it will still work in relation to the dependency issues that are still there.