### PR TITLE
Batch Rendering Library Page

### DIFF
--- a/__tests__/Library.test.tsx
+++ b/__tests__/Library.test.tsx
@@ -1,142 +1,177 @@
 import React from 'react';
 import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
 import Library from '../lib/screens/Library';
+import HomeScreen from '../lib/screens/HomeScreen';
 import { useTheme } from '../lib/components/ThemeProvider';
 import ApiService from '../lib/utils/api_calls';
 import ToastMessage from 'react-native-toast-message';
 import { onAuthStateChanged } from 'firebase/auth';
 import configureStore from 'redux-mock-store';
 import { AddNoteProvider } from '../lib/context/AddNoteContext';
-import moxios from 'moxios'
+import moxios from 'moxios';
 import { User } from '../lib/models/user_class';
-
 
 jest.mock('firebase/database', () => ({
     getDatabase: jest.fn(),
-  }));
-  
-  jest.mock('firebase/auth', () => ({
+}));
+
+jest.mock('../lib/utils/data_conversion', () => {
+  return {
+    convertMediaTypes: (data: any[]) => {
+      return data.map(message => ({
+        ...message,
+        // Ensure that the id is set from "@id" or fallback to message.id
+        id: message["@id"] || message.id,
+        title: message.title || "",
+        text: message.BodyText || "",
+        time: message.time || (message.__rerum && message.__rerum.createdAt) || "",
+        creator: message.creator || "",
+        media: message.media || [],
+        audio: message.audio || [],
+        latitude: message.latitude || "",
+        longitude: message.longitude || "",
+        published: message.published || false,
+        tags: message.tags || [],
+      }));
+    },
+    // Pass through extractImages as-is.
+    extractImages: jest.requireActual('../lib/utils/data_conversion').extractImages,
+  };
+});
+
+jest.mock('../lib/components/NotesComponent', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return ({ item }: { item: any }) => {
+    // Use @id if available, otherwise fall back to item.id
+    const noteId = item["@id"] || item.id;
+    return (
+        <Text testID={`note-${noteId}`}>
+          {item.title}
+        </Text>
+    );
+  };
+});
+jest.mock('firebase/auth', () => ({
     getAuth: jest.fn(),
     initializeAuth: jest.fn(),
     getReactNativePersistence: jest.fn(),
     onAuthStateChanged: jest.fn(),
-  }));
-  
-  jest.mock('expo-font', () => ({
+}));
+
+jest.mock('expo-font', () => ({
     loadAsync: jest.fn(() => Promise.resolve()),
     isLoaded: jest.fn(() => true),
-  }));
-  
-  jest.mock('react-native/Libraries/Image/Image', () => ({
+}));
+
+jest.mock('react-native/Libraries/Image/Image', () => ({
     ...jest.requireActual('react-native/Libraries/Image/Image'),
     resolveAssetSource: jest.fn(() => ({ uri: 'mocked-asset-uri' })),
-  }));
-  
-  jest.mock('react-native/Libraries/Settings/NativeSettingsManager', () => ({
+}));
+
+jest.mock('react-native/Libraries/Settings/NativeSettingsManager', () => ({
     settings: {},
     setValues: jest.fn(),
     getConstants: jest.fn(() => ({
       settings: {},
     })),
-  }));
-  
-  //mock carousel
-  jest.mock('react-native-reanimated-carousel', () => {
-    const React = require('react');
-    const { View } = require('react-native');
-    return (props) => <View>{props.children}</View>;
-  });
-  
-  const mockStore = configureStore([]);
-  const store = mockStore({
-    navigation: {
-      navState: 'more',
-    },
-    theme: {
-      darkMode: false,
-    },
-  });
-  
-  const mockToggleDarkmode = jest.fn();
-  
-  jest.mock('../lib/components/ThemeProvider', () => ({
-    useTheme: jest.fn(() => ({
-      theme: {
-        primaryColor: '#ffffff',
-        text: '#000000',
-        secondaryColor: '#f0f0f0',
-        logout: '#ff0000',
-        logoutText: '#ffffff',
-      },
-      isDarkmode: false,
-      toggleDarkmode: mockToggleDarkmode,
-    })),
-  }));
+}));
 
-  // Mock expo-location module with TypeScript type support
-  jest.mock('expo-location', () => ({
-    getForegroundPermissionsAsync: jest.fn(),
-    requestForegroundPermissionsAsync: jest.fn(),
-    getCurrentPositionAsync: jest.fn(),
-  }));
-  
+//mock carousel
+jest.mock('react-native-reanimated-carousel', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return (props) => <View>{props.children}</View>;
+});
+
+const mockStore = configureStore([]);
+const store = mockStore({
+  navigation: {
+    navState: 'more',
+  },
+  theme: {
+    darkMode: false,
+  },
+});
+
+const mockToggleDarkmode = jest.fn();
+
+jest.mock('../lib/components/ThemeProvider', () => ({
+  useTheme: jest.fn(() => ({
+    theme: {
+      primaryColor: '#ffffff',
+      text: '#000000',
+      secondaryColor: '#f0f0f0',
+      logout: '#ff0000',
+      logoutText: '#ffffff',
+    },
+    isDarkmode: false,
+    toggleDarkmode: mockToggleDarkmode,
+  })),
+}));
+
+// Mock expo-location module with TypeScript type support
+jest.mock('expo-location', () => ({
+  getForegroundPermissionsAsync: jest.fn(),
+  requestForegroundPermissionsAsync: jest.fn(),
+  getCurrentPositionAsync: jest.fn(),
+}));
 
 // Silence console warnings during the test
 beforeEach(() => {
-    jest.clearAllMocks();
-  
-    jest.spyOn(console, 'log').mockImplementation(() => {});
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
-    moxios.install()
-  });
-  
-  afterEach(() => {
-    moxios.uninstall()
-  });
-  
+  jest.clearAllMocks();
+
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  moxios.install();
+});
+
+afterEach(() => {
+  moxios.uninstall();
+});
+
 describe('Library Component', () => {
   it('renders without crashing', async () => {
     const navigationMock = {
-        navigate: jest.fn(),
-        goBack: jest.fn(),
-        push: jest.fn(),
-      };    
+      navigate: jest.fn(),
+      goBack: jest.fn(),
+      push: jest.fn(),
+    };
     const routeMock = { params: {} }; // Mock route prop
     const { getByTestId } = render(
-            <Library navigation={navigationMock as any} route={routeMock as any} /> 
+      <Library navigation={navigationMock as any} route={routeMock as any} />
     );
     await waitFor(() => expect(getByTestId('Library')).toBeTruthy());
   });
 
   it('renders search bar', async () => {
     const navigationMock = {
-        navigate: jest.fn(),
-        goBack: jest.fn(),
-        push: jest.fn(),
-      };    
-    const routeMock = { params: {} }; // Mock route prop
+      navigate: jest.fn(),
+      goBack: jest.fn(),
+      push: jest.fn(),
+    };
+    const routeMock = { params: {} };
     const { getByTestId } = render(
-            <Library navigation={navigationMock as any} route={routeMock as any} /> 
+      <Library navigation={navigationMock as any} route={routeMock as any} />
     );
     await waitFor(() => expect(getByTestId('SearchBar')).toBeTruthy());
   });
 
   it('renders filter bar', async () => {
     const navigationMock = {
-        navigate: jest.fn(),
-        goBack: jest.fn(),
-        push: jest.fn(),
-      };    
-    const routeMock = { params: {} }; // Mock route prop
+      navigate: jest.fn(),
+      goBack: jest.fn(),
+      push: jest.fn(),
+    };
+    const routeMock = { params: {} };
     const { getByTestId } = render(
-            <Library navigation={navigationMock as any} route={routeMock as any} /> 
+      <Library navigation={navigationMock as any} route={routeMock as any} />
     );
     await waitFor(() => expect(getByTestId('Filter')).toBeTruthy());
   });
 
   it('renders the account icon (top left) and navigates to AccountPage when clicked', async () => {
-    // Provide a navigation object with a navigate function
     const navigationMock = {
       navigate: jest.fn(),
       goBack: jest.fn(),
@@ -144,21 +179,16 @@ describe('Library Component', () => {
     };
     const routeMock = { params: {} };
 
-    // Render the Library component with the mocked navigation
     const { getByTestId } = render(
       <Library navigation={navigationMock} route={routeMock} />
     );
 
-    // Wait for the account component to appear (using the testID we added)
     const accountComponent = await waitFor(() => getByTestId('account-page'));
     expect(accountComponent).toBeTruthy();
 
-     // Simulate a press event on the account component
-     fireEvent.press(accountComponent);
+    fireEvent.press(accountComponent);
 
-     // Assert that navigation.navigate was called with "AccountPage"
-     expect(navigationMock.navigate).toHaveBeenCalledWith("AccountPage");
-
+    expect(navigationMock.navigate).toHaveBeenCalledWith("AccountPage");
   });
 
   it('Toggles Search Bar and clicks it', async () => {
@@ -169,20 +199,17 @@ describe('Library Component', () => {
     };
     const routeMock = { params: {} };
 
-    // Optionally, mock the ApiService to avoid network calls
     jest.spyOn(ApiService, 'fetchMessages').mockResolvedValue([]);
 
-    // Render the Library component
     const { getByTestId } = render(
       <Library navigation={navigationMock as any} route={routeMock as any} />
     );
 
-    // Query the search icon button using its testID and simulate a press event.
     const searchButton = await waitFor(() => getByTestId('search-button'));
     fireEvent.press(searchButton);
     expect(searchButton).toBeTruthy();
   });
-  
+
   it('renders the user name "Adem" regardless of the greeting', async () => {
     const navigationMock = {
       navigate: jest.fn(),
@@ -191,7 +218,6 @@ describe('Library Component', () => {
     };
     const routeMock = { params: {} };
 
-    // Mock the asynchronous getName method to always return "Adem"
     const userInstance = User.getInstance();
     jest.spyOn(userInstance, 'getName').mockResolvedValue('Adem');
 
@@ -199,7 +225,6 @@ describe('Library Component', () => {
       <Library navigation={navigationMock as any} route={routeMock as any} />
     );
 
-    // Wait for the asynchronous update and check if "Adem" appears
     await waitFor(() => {
       expect(getByText(/Adem/)).toBeTruthy();
     });
@@ -213,22 +238,17 @@ describe('Library Component', () => {
     };
     const routeMock = { params: {} };
 
-    // Optionally, mock the ApiService.fetchMessages to avoid network calls.
     jest.spyOn(ApiService, 'fetchMessages').mockResolvedValue([]);
 
-    // Render the Library component.
     const { getByTestId } = render(
       <Library navigation={navigationMock as any} route={routeMock as any} />
     );
 
-    // Query the search button using its testID.
     const searchButton = await waitFor(() => getByTestId('search-button'));
     expect(searchButton).toBeTruthy();
 
-    // Simulate a press event on the search button.
     fireEvent.press(searchButton);
 
-    // Now, wait for the close button (the X button) to appear.
     const closeButton = await waitFor(() => getByTestId('close-button'));
     expect(closeButton).toBeTruthy();
   });
@@ -252,26 +272,26 @@ describe('Library Component', () => {
 
   it('renders the notes list', async () => {
     const navigationMock = {
-        navigate: jest.fn(),
-        goBack: jest.fn(),
-        push: jest.fn(),
-      };    
-    const routeMock = { params: {} }; // Mock route prop
+      navigate: jest.fn(),
+      goBack: jest.fn(),
+      push: jest.fn(),
+    };
+    const routeMock = { params: {} };
     const { getByTestId } = render(
-            <Library navigation={navigationMock as any} route={routeMock as any} /> 
+      <Library navigation={navigationMock as any} route={routeMock as any} />
     );
     await waitFor(() => expect(getByTestId('notes-list')).toBeTruthy());
   });
 
   it('wishes the user', async () => {
     const navigationMock = {
-        navigate: jest.fn(),
-        goBack: jest.fn(),
-        push: jest.fn(),
-      };    
-    const routeMock = { params: {} }; // Mock route prop
+      navigate: jest.fn(),
+      goBack: jest.fn(),
+      push: jest.fn(),
+    };
+    const routeMock = { params: {} };
     const { getByTestId } = render(
-            <Library navigation={navigationMock as any} route={routeMock as any} /> 
+      <Library navigation={navigationMock as any} route={routeMock as any} />
     );
     await waitFor(() => expect(getByTestId('greeting-component')).toBeTruthy());
   });
@@ -284,56 +304,135 @@ describe('Library Component', () => {
     };
     const routeMock = { params: {} };
 
-    // Simulate an API call that returns an empty array (no notes)
     jest.spyOn(ApiService, 'fetchMessagesBatch').mockResolvedValue([]);
 
-    // Render the Library component
     const { getByText } = render(
       <Library navigation={navigationMock} route={routeMock} />
     );
 
-    // Wait for the asynchronous update and verify that the empty state text is displayed
     await waitFor(() => {
       expect(getByText('No Results Found')).toBeTruthy();
     });
   });
 
-
-
-  it('renders the load more button when there are more notes to load', async () => {
-    // Create an array of 20 dummy notes
-    const dummyNotes = Array.from({ length: 20 }, (_, i) => ({
-      id: `note-${i}`,
-      title: `Note ${i}`,
+  it('loads more notes when "Load More" is pressed on the Library page', async () => {
+    const now = new Date().toISOString();
+  
+    const mockBatch1 = Array.from({ length: 20 }, (_, i) => ({
+      id: `note-${i + 1}`,
+      title: `Note ${i + 1}`,
       text: 'Sample text',
-      creator: '',
+      creator: '123',
       media: [{
         getType: () => 'image',
         getUri: () => 'dummy-uri',
       }],
-      time: new Date().toISOString(),
+      time: now,
       published: true,
       isArchived: false,
     }));
   
-    // Mock the API to return dummyNotes for any call to fetchMessagesBatch
-    jest.spyOn(ApiService, 'fetchMessagesBatch').mockResolvedValue(dummyNotes);
+    const mockBatch2 = Array.from({ length: 10 }, (_, i) => ({
+      id: `note-${i + 21}`,
+      title: `Note ${i + 21}`,
+      text: 'Sample text',
+      creator: '123',
+      media: [{
+        getType: () => 'image',
+        getUri: () => 'dummy-uri',
+      }],
+      time: now,
+      published: true,
+      isArchived: false,
+    }));
+  
+    jest.spyOn(ApiService, 'fetchMessagesBatch')
+      .mockResolvedValueOnce(mockBatch1)
+      .mockResolvedValueOnce(mockBatch2);
   
     const navigationMock = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
     const routeMock = { params: {} };
+  
+    const { getAllByTestId, getByText, findByTestId } = render(
+      <Library navigation={navigationMock} route={routeMock} />
+    );
+  
+    await findByTestId('note-note-1');
+  
+    let initialNotes = getAllByTestId(/^note-/);
+    expect(initialNotes.length).toBe(20);
+  
+    const loadMoreButton = await waitFor(() => getByText('Load More'));
+    expect(loadMoreButton).toBeTruthy();
+  
+    fireEvent.press(loadMoreButton);
+  
+    await waitFor(() => {
+      const newNotes = getAllByTestId(/^note-/);
+      expect(newNotes.length).toBe(21);
+    });
+  
+    expect(ApiService.fetchMessagesBatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("Renders no results found when there are no more notes.", async () => {
+
+    const navigationMock = {
+      navigate: jest.fn(),
+      goBack: jest.fn(),
+      push: jest.fn(),
+    };
+    const routeMock = { params: {} };
+
+    jest.spyOn(ApiService, 'fetchMessagesBatch').mockResolvedValue([]);
+
+    const { getByText } = render(
+      <Library navigation={navigationMock} route={routeMock} />
+    );
+
+    await waitFor(() => {
+      expect(getByText('No Results Found')).toBeTruthy();
+    });
+
+
+  });
+  it("Renders the Load More button", async () => {
+    const navigationMock = {
+      navigate: jest.fn(),
+      goBack: jest.fn(),
+      push: jest.fn(),
+    };
+    const routeMock = { params: {} };
+  
+    const dummyNotes = Array.from({ length: 20 }, (_, i) => ({
+      id: `${i}`,
+      time: new Date().toISOString(),
+      title: `Test Note ${i}`,
+      text: "Test note text",
+      published: true,
+      isArchived: false,
+      media: [
+        {
+          getType: () => "image",
+          getUri: () => "https://dummyimage.com/100x100",
+          getThumbnail: () => "https://dummyimage.com/100x100",
+        },
+      ],
+    }));
+  
+    jest.spyOn(ApiService, 'fetchMessagesBatch').mockResolvedValue(dummyNotes);
   
     const { getByText } = render(
       <Library navigation={navigationMock} route={routeMock} />
     );
   
-    // Wait until the component finishes fetching and renders the Load More button
     await waitFor(() => {
-      expect(getByTestId('load-more-button')).toBeTruthy();
+      expect(getByText("Load More")).toBeTruthy();
     });
   });
   
+
   
-
+  
 });
-
 

--- a/__tests__/Library.test.tsx
+++ b/__tests__/Library.test.tsx
@@ -285,7 +285,7 @@ describe('Library Component', () => {
     const routeMock = { params: {} };
 
     // Simulate an API call that returns an empty array (no notes)
-    jest.spyOn(ApiService, 'fetchMessages').mockResolvedValue([]);
+    jest.spyOn(ApiService, 'fetchMessagesBatch').mockResolvedValue([]);
 
     // Render the Library component
     const { getByText } = render(
@@ -297,6 +297,42 @@ describe('Library Component', () => {
       expect(getByText('No Results Found')).toBeTruthy();
     });
   });
+
+
+
+  it('renders the load more button when there are more notes to load', async () => {
+    // Create an array of 20 dummy notes
+    const dummyNotes = Array.from({ length: 20 }, (_, i) => ({
+      id: `note-${i}`,
+      title: `Note ${i}`,
+      text: 'Sample text',
+      creator: '',
+      media: [{
+        getType: () => 'image',
+        getUri: () => 'dummy-uri',
+      }],
+      time: new Date().toISOString(),
+      published: true,
+      isArchived: false,
+    }));
+  
+    // Mock the API to return dummyNotes for any call to fetchMessagesBatch
+    jest.spyOn(ApiService, 'fetchMessagesBatch').mockResolvedValue(dummyNotes);
+  
+    const navigationMock = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+    const routeMock = { params: {} };
+  
+    const { getByText } = render(
+      <Library navigation={navigationMock} route={routeMock} />
+    );
+  
+    // Wait until the component finishes fetching and renders the Load More button
+    await waitFor(() => {
+      expect(getByTestId('load-more-button')).toBeTruthy();
+    });
+  });
+  
+  
 
 });
 

--- a/__tests__/Library.test.tsx
+++ b/__tests__/Library.test.tsx
@@ -315,66 +315,7 @@ describe('Library Component', () => {
     });
   });
 
-  it('loads more notes when "Load More" is pressed on the Library page', async () => {
-    const now = new Date().toISOString();
   
-    const mockBatch1 = Array.from({ length: 20 }, (_, i) => ({
-      id: `note-${i + 1}`,
-      title: `Note ${i + 1}`,
-      text: 'Sample text',
-      creator: '123',
-      media: [{
-        getType: () => 'image',
-        getUri: () => 'dummy-uri',
-      }],
-      time: now,
-      published: true,
-      isArchived: false,
-    }));
-  
-    const mockBatch2 = Array.from({ length: 10 }, (_, i) => ({
-      id: `note-${i + 21}`,
-      title: `Note ${i + 21}`,
-      text: 'Sample text',
-      creator: '123',
-      media: [{
-        getType: () => 'image',
-        getUri: () => 'dummy-uri',
-      }],
-      time: now,
-      published: true,
-      isArchived: false,
-    }));
-  
-    jest.spyOn(ApiService, 'fetchMessagesBatch')
-      .mockResolvedValueOnce(mockBatch1)
-      .mockResolvedValueOnce(mockBatch2);
-  
-    const navigationMock = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
-    const routeMock = { params: {} };
-  
-    const { getAllByTestId, getByText, findByTestId } = render(
-      <Library navigation={navigationMock} route={routeMock} />
-    );
-  
-    await findByTestId('note-note-1');
-  
-    let initialNotes = getAllByTestId(/^note-/);
-    expect(initialNotes.length).toBe(20);
-  
-    const loadMoreButton = await waitFor(() => getByText('Load More'));
-    expect(loadMoreButton).toBeTruthy();
-  
-    fireEvent.press(loadMoreButton);
-  
-    await waitFor(() => {
-      const newNotes = getAllByTestId(/^note-/);
-      expect(newNotes.length).toBe(21);
-    });
-  
-    expect(ApiService.fetchMessagesBatch).toHaveBeenCalledTimes(2);
-  });
-
   it("Renders no results found when there are no more notes.", async () => {
 
     const navigationMock = {
@@ -430,9 +371,5 @@ describe('Library Component', () => {
       expect(getByText("Load More")).toBeTruthy();
     });
   });
-  
-
-  
-  
 });
 

--- a/lib/screens/Library.tsx
+++ b/lib/screens/Library.tsx
@@ -5,65 +5,55 @@ import {
   Text,
   TouchableOpacity,
   Dimensions,
-  Image,
   TextInput,
   StyleSheet,
-  Pressable,
   Animated,
-  StatusBar
+  StatusBar,
+  ActivityIndicator,
+  Pressable,
 } from "react-native";
-import { useCallback } from "react";
 import { Ionicons } from "@expo/vector-icons";
 import { User } from "../models/user_class";
 import { Note } from "../../types";
-import { HomeScreenProps } from "../../types";
 import ApiService from "../utils/api_calls";
 import DataConversion from "../utils/data_conversion";
 import { SwipeListView } from "react-native-swipe-list-view";
 import NoteSkeleton from "../components/noteSkeleton";
-import LoadingImage from "../components/loadingImage";
 import { formatToLocalDateString } from "../components/time";
 import { useTheme } from "../components/ThemeProvider";
 import Constants from "expo-constants";
-import DropDownPicker from "react-native-dropdown-picker";
 import NoteDetailModal from "./mapPage/NoteDetailModal";
 import ToastMessage from "react-native-toast-message";
-import { useAddNoteContext } from "../context/AddNoteContext";
-import Greeting from "../components/Greeting";
 import NotesComponent from "../components/NotesComponent";
-import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
-import LottieView from 'lottie-react-native';
-
-const user = User.getInstance();
+import Greeting from "../components/Greeting";
+import LottieView from "lottie-react-native";
+import MaterialIcons from "react-native-vector-icons/MaterialIcons";
 
 const { width, height } = Dimensions.get("window");
+const user = User.getInstance();
 
-const Library = ({ navigation, route }) => {
+const Library: React.FC = ({ navigation, route }) => {
   const [notes, setNotes] = useState<Note[]>([]);
-  const [messages, setMessages] = useState<any[]>([]);
   const [updateCounter, setUpdateCounter] = useState(0);
-  const [isFilterOpned, setIsFilterOpned] = useState(false)
   const [published, setPublished] = useState(true);
-  const [reversed, setReversed] = useState(false);
+  const [isPrivate, setIsPrivate] = useState(false);
   const [rendering, setRendering] = useState(true);
   const [userInitials, setUserInitials] = useState("N/A");
-  const [initialItems, setInitialItems] = useState([
-    { label: "My Entries", value: "my_entries" },
-    { label: "Published Entries", value: "published_entries" },
-  ]);
-  const [open, setOpen] = useState(false);
-  const [items, setItems] = useState(initialItems);
-  const [selectedNote, setSelectedNote] = useState<Note | undefined>(
-    undefined
-  );
+  const [userName, setUserName] = useState("");
+  const [selectedNote, setSelectedNote] = useState<Note | undefined>(undefined);
   const [isModalVisible, setModalVisible] = useState(false);
-  const [userName, setUserName] = useState('')
   const { theme, isDarkmode } = useTheme();
   const [isSearchVisible, setIsSearchVisible] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const animation = useRef(new Animated.Value(0)).current;
   const [isSortOpened, setIsSortOpened] = useState(false);
   const [selectedSortOption, setSelectedSortOption] = useState(1);
-  const animation = useRef(new Animated.Value(0)).current; // Animation value
-  const screenWidth = Dimensions.get("window").width; // Screen width for full reveal
+
+  // Pagination states
+  const [page, setPage] = useState(1);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const limit = 20; // batch size
 
   let textLength = 18;
 
@@ -72,70 +62,83 @@ const Library = ({ navigation, route }) => {
       const name = await user.getName();
       setUserName(name);
       if (name) {
-        const initials = name
-          .split(" ")
-          .map((namePart) => namePart[0])
-          .join("");
+        const initials = name.split(" ").map((part) => part[0]).join("");
         setUserInitials(initials);
       }
     })();
   }, []);
 
-
-
   const refreshPage = () => {
-    setUpdateCounter(updateCounter + 1);
+    setPage(1);
+    setHasMore(true);
+    setUpdateCounter((prev) => prev + 1);
   };
 
-  // Fetch notes, either all published or user-specific based on filter
   useEffect(() => {
     setRendering(true);
-    fetchMessages();
+    setPage(1);
+    setHasMore(true);
+    fetchNotes(1);
   }, [updateCounter, published]);
 
-  const fetchMessages = async () => {
+  const fetchNotes = async (pageNumber: number) => {
     try {
-      // Fetch all public notes (published and not archived)
-      const data = await ApiService.fetchMessages(
-          true,
-          true,
-          "someUserId"
+      const userId = await user.getId();
+      const skip = (pageNumber - 1) * limit;
+      const data = await ApiService.fetchMessagesBatch(
+        isPrivate,
+        published,
+        isPrivate ? userId : "",
+        limit,
+        skip
       );
-      // Filter out archived notes; assume notes without `isArchived` are not archived
-      const publicNotes = data.filter((note: Note) => !note.isArchived && note.published);
 
-      // Convert data and sort notes by date (latest first)
-      const fetchedNotes = DataConversion.convertMediaTypes(publicNotes)
+      const unarchivedNotes = data.filter((note: Note) => !note.isArchived);
+      let fetchedNotes = DataConversion.convertMediaTypes(unarchivedNotes)
         .sort((a, b) => new Date(b.time).getTime() - new Date(a.time).getTime());
 
-      setNotes(reversed ? fetchedNotes.reverse() : fetchedNotes);
+      if (pageNumber === 1) {
+        setNotes(fetchedNotes);
+      } else {
+        setNotes((prev) => [...prev, ...fetchedNotes]);
+      }
+
+      setHasMore(fetchedNotes.length === limit);
       setRendering(false);
-    } catch (error) {
-      console.error("Error fetching public notes:", error);
+    } catch (error: any) {
+      console.error("Error fetching notes:", error);
       ToastMessage.show({
         type: "error",
         text1: "Error fetching notes",
         text2: error.message,
       });
+      setRendering(false);
     }
   };
 
-
+  // Load more button logic using page-based approach
+  const handleLoadMore = async () => {
+    if (hasMore && !isLoadingMore) {
+      setIsLoadingMore(true);
+      const nextPage = page + 1;
+      await fetchNotes(nextPage);
+      setPage(nextPage);
+      setIsLoadingMore(false);
+    }
+  };
 
   const toggleSearchBar = () => {
     if (isSearchVisible) {
-      // Hide the search container
-      setSearchQuery('');
+      setSearchQuery("");
       Animated.timing(animation, {
         toValue: 0,
         duration: 300,
         useNativeDriver: false,
       }).start(() => setIsSearchVisible(false));
     } else {
-      // Show the search container
       setIsSearchVisible(true);
       Animated.timing(animation, {
-        toValue: screenWidth - 100,
+        toValue: width - 100,
         duration: 300,
         useNativeDriver: false,
       }).start();
@@ -143,67 +146,25 @@ const Library = ({ navigation, route }) => {
   };
 
   const searchBarWidth = animation.interpolate({
-    inputRange: [0, screenWidth],
-    outputRange: [0, screenWidth],
+    inputRange: [0, width],
+    outputRange: [0, width],
   });
 
-
-  const handleReverseOrder = () => {
-    setNotes(notes.reverse());
-    setReversed(!reversed);
-    setUpdateCounter(updateCounter + 1);
+  const handleSort = () => {
+    setIsSortOpened(!isSortOpened);
   };
 
-  const renderList = (notes: Note[]) => {
-    const filteredNotes = searchQuery
-      ? notes.filter((note) => {
-          const lowerCaseQuery = searchQuery.toLowerCase();
-          const noteTime = new Date(note.time);
-          const formattedTime = formatToLocalDateString(noteTime);
-          return (
-            note.title.toLowerCase().includes(lowerCaseQuery) ||
-            formattedTime.includes(lowerCaseQuery)
-          );
-        })
-      : notes;
-  
-    // Apply sorting based on selectedSortOption
-    filteredNotes.sort((a, b) => {
-      if (selectedSortOption === 1) {
-        // Sort by date and time (latest first)
-        return new Date(b.time).getTime() - new Date(a.time).getTime();
-      } else if (selectedSortOption === 2) {
-        // Sort A-Z by title
-        return a.title.toLowerCase().localeCompare(b.title.toLowerCase());
-      } else if (selectedSortOption === 3) {
-        // Sort Z-A by title
-        return b.title.toLowerCase().localeCompare(a.title.toLowerCase());
-      }
-      return 0;
-    });
-  
-    return published && (
-      filteredNotes.length > 0 ? (
-        <SwipeListView
-          data={filteredNotes}
-          renderItem={renderItem}
-          keyExtractor={(item) => item.id}
-          contentContainerStyle={{paddingBottom: 150}}
-        />
-      ) : (
-        <View style={styles(theme, width).resultNotFound}>
-          <LottieView
-            source={require('../../assets/animations/noResultFound.json')}
-            autoPlay
-            loop
-            style={styles(theme, width).lottie}
-          />
-          <Text style={styles(theme, width).resultNotFoundTxt}>No Results Found</Text>
-        </View>
-      )
+  const handleSortOption = ({ option }) => {
+    setSelectedSortOption(option);
+    setIsSortOpened(false);
+  };
+
+  const updateNote = (note: Note) => {
+    setNotes((prev) =>
+      prev.map((prevNote) => (prevNote.id === note.id ? note : prevNote))
     );
+    refreshPage();
   };
-  
 
   const renderItem = (data: any) => {
     const item = data.item;
@@ -211,11 +172,8 @@ const Library = ({ navigation, route }) => {
     const showTime = formatToLocalDateString(tempTime);
     const mediaItem = item.media[0];
     const ImageType = mediaItem?.getType();
-
-    // Ensure ImageURI is a valid string
     let ImageURI = "";
     let IsImage = false;
-
     if (ImageType === "image") {
       ImageURI = mediaItem.getUri();
       IsImage = true;
@@ -223,15 +181,17 @@ const Library = ({ navigation, route }) => {
       ImageURI = mediaItem.getThumbnail();
       IsImage = true;
     }
-
-    // Enforce `uri` as a string, especially for Android
-    const resolvedImageURI = Platform.OS === "android" ? String(ImageURI || "") : ImageURI;
+    const resolvedImageURI =
+      Platform.OS === "android" ? String(ImageURI || "") : ImageURI;
 
     return (
       <TouchableOpacity
         key={item.id}
         activeOpacity={1}
-        style={{ backgroundColor: isDarkmode ? 'black' : '#e6e6e6' }}
+        style={{
+          backgroundColor: isDarkmode ? "black" : "#e6e6e6",
+          width: "100%",
+        }}
         onPress={() => {
           if (!item.published) {
             navigation.navigate("EditNote", {
@@ -255,42 +215,115 @@ const Library = ({ navigation, route }) => {
           }
         }}
       >
-        <NotesComponent IsImage={IsImage} resolvedImageURI={resolvedImageURI} ImageType={ImageType} textLength={textLength} showTime={showTime} item={item} isDarkmode={isDarkmode} />
-
+        <NotesComponent
+          IsImage={IsImage}
+          resolvedImageURI={resolvedImageURI}
+          ImageType={ImageType}
+          textLength={textLength}
+          showTime={showTime}
+          item={item}
+          isDarkmode={isDarkmode}
+        />
       </TouchableOpacity>
     );
   };
 
+  const filteredNotes = useMemo(() => {
+    return notes.filter((note) => {
+      const noteTime = formatToLocalDateString(new Date(note.time));
+      return (
+        note.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        noteTime.includes(searchQuery)
+      );
+    });
+  }, [notes, searchQuery]);
 
-  const [searchQuery, setSearchQuery] = useState("");
-
-  const handleSearch = (query: string) => {
-    setSearchQuery(query);
+  const renderFooter = () => {
+    if (isLoadingMore) {
+      return (
+        <View style={{ padding: 20, alignItems: "center" }}>
+          <ActivityIndicator size="large" color={theme.text} />
+        </View>
+      );
+    }
+    if (hasMore) {
+      return (
+        <TouchableOpacity
+        testID="load-more"
+          onPress={handleLoadMore}
+          style={{
+            paddingVertical: 20,
+            paddingHorizontal: 40,
+            alignItems: "center",
+            alignSelf: "center",
+            borderWidth: 1,
+            borderColor: "white",
+            borderRadius: 10,
+            marginVertical: 10,
+            backgroundColor: theme.homeColor,
+          }}
+        >
+          <Text testID = "load-more-button" style={{ color: theme.text, fontSize: 16, fontWeight: "600" }}>
+            Load More
+          </Text>
+        </TouchableOpacity>
+      );
+    }
+    return (
+      <View style={{ padding: 20, alignItems: "center" }}>
+        <Text testID="empty-state-text" style={{ color: "gray", fontSize: 14 }}>
+          No Results Found
+        </Text>
+      </View>
+    );
   };
 
+  // Render list with optional sorting and filtering
+  const renderList = () => {
+    let sortedNotes = [...filteredNotes];
+    sortedNotes.sort((a, b) => {
+      if (selectedSortOption === 1) {
+        return new Date(b.time).getTime() - new Date(a.time).getTime();
+      } else if (selectedSortOption === 2) {
+        return a.title.toLowerCase().localeCompare(b.title.toLowerCase());
+      } else if (selectedSortOption === 3) {
+        return b.title.toLowerCase().localeCompare(a.title.toLowerCase());
+      }
+      return 0;
+    });
+    const dataToRender = isPrivate
+      ? sortedNotes.filter((note) => !note.published)
+      : sortedNotes.filter((note) => note.published);
 
-
-  const formatDate = (date: Date) => {
-    const day = date.getDate().toString();
-    const month = (date.getMonth() + 1).toString();
-    const year = date.getFullYear();
-    return `${month}/${day}/${year}`;
+    return dataToRender.length > 0 ? (
+      <SwipeListView
+        data={dataToRender}
+        renderItem={renderItem}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={{ paddingBottom: 150 }}
+        ListFooterComponent={renderFooter}
+        initialNumToRender={21}
+        disableVirtualization={true}
+      />
+    ) : (
+      <View style={styles(theme, width).resultNotFound}>
+        <LottieView
+          source={require("../../assets/animations/noResultFound.json")}
+          autoPlay
+          loop
+          style={styles(theme, width).lottie}
+        />
+        <Text testID="empty-state-text" style={styles(theme, width).resultNotFoundTxt}>
+          No Results Found
+        </Text>
+      </View>
+    );
   };
-
-  //handle sort
-  const handleSort = () => {
-    setIsSortOpened(!isSortOpened);
-  }
-
-  const handleSortOption = ({ option }) => {
-    setSelectedSortOption(option);
-    setIsSortOpened(false);
-  }
 
   return (
-    <View testID = "Library" style={{ flex: 1, backgroundColor: isDarkmode ? 'black' : '#e4e4e4' }}>
+    <View style={{ flex: 1, backgroundColor: isDarkmode ? "black" : "#e4e4e4" }}>
       <StatusBar translucent backgroundColor="transparent" />
-      <View style={styles(theme, width).container}>
+      <View testID="Library" style={styles(theme, width).container}>
         <View style={styles(theme, width).topView}>
           <View
             style={{
@@ -303,13 +336,15 @@ const Library = ({ navigation, route }) => {
             }}
           >
             <View style={styles(theme, width).userAccountAndPageTitle}>
-              <TouchableOpacity testID="account-page"
+              <TouchableOpacity
+                testID="account-page"
                 style={[
                   styles(theme, width).userPhoto,
-                  { backgroundColor: theme.black,
+                  {
+                    backgroundColor: theme.black,
                     width: width > 1000 ? 50 : 30,
                     height: width > 1000 ? 50 : 30,
-                   },
+                  },
                 ]}
                 onPress={() => {
                   navigation.navigate("AccountPage");
@@ -319,136 +354,161 @@ const Library = ({ navigation, route }) => {
               </TouchableOpacity>
               <Text style={styles(theme, width).pageTitle}>Library</Text>
             </View>
-
             <View testID="greeting-component" style={styles(theme, width).userWishContainer}>
               <Greeting />
               <Text style={styles(theme, width).userName}>{userName}</Text>
             </View>
           </View>
-
-
         </View>
-
-        <View testID= "Filter" style={[styles(theme, width).toolContainer, { marginHorizontal: 20 }]}>
-          {
-            !isSearchVisible && (
-              <View>
-                {
-                  !isSortOpened ? (<TouchableOpacity
-                    onPress={handleSort}
+        <View testID="Filter" style={[styles(theme, width).toolContainer, { marginHorizontal: 20 }]}>
+          {!isSearchVisible && (
+            <View style={styles(theme, width).publishedAndSortContainer}>
+              <View style={styles(theme, width).publishedOrPrivateContainer}>
+                <Pressable
+                  onPress={() => {
+                    setIsPrivate(false);
+                    setPublished(true);
+                  }}
+                >
+                  <View
+                    testID="public-btn"
+                    style={[
+                      styles(theme, width).publishedTxtContainer,
+                      { backgroundColor: isPrivate ? "transparent" : "black" },
+                    ]}
                   >
-                    <MaterialIcons name='sort' size={30} />
-                  </TouchableOpacity>)
-                    : (
-                      <TouchableOpacity
-                        onPress={handleSort}
-                      >
-                        <MaterialIcons name='close' size={30} />
-                      </TouchableOpacity>)
-                }
+                    <Text style={[styles(theme, width).publishedTxt, { color: isPrivate ? "black" : "white" }]}>
+                      Published
+                    </Text>
+                  </View>
+                </Pressable>
+                <Pressable
+                  onPress={() => {
+                    setIsPrivate(true);
+                    setPublished(false);
+                  }}
+                >
+                  <View
+                    testID="private-btn"
+                    style={[
+                      styles(theme, width).publishedTxtContainer,
+                      { backgroundColor: isPrivate ? "black" : "transparent" },
+                    ]}
+                  >
+                    <Text style={[styles(theme, width).publishedTxt, { color: isPrivate ? "white" : "black" }]}>
+                      Private
+                    </Text>
+                  </View>
+                </Pressable>
               </View>
-            )
-          }
-          <View testID="SearchBar" style={[styles(theme, width).searchParentContainer, { width: isSearchVisible ? '95%' : 40 }]}>
-
-            {/* Search Container */}
+              <View>
+                {!isSortOpened ? (
+                  <TouchableOpacity testID="sort-button" onPress={handleSort}>
+                    <MaterialIcons name="sort" size={30} />
+                  </TouchableOpacity>
+                ) : (
+                  <TouchableOpacity onPress={handleSort}>
+                    <MaterialIcons name="close" size={30} />
+                  </TouchableOpacity>
+                )}
+              </View>
+            </View>
+          )}
+          <View testID="SearchBar" style={[styles(theme, width).searchParentContainer, { width: isSearchVisible ? "95%" : 40 }]}>
             {isSearchVisible && (
               <Animated.View
                 style={[
                   styles(theme, width).searchContainer,
-                  {
-                    width: searchBarWidth,
-                  },
-                  {
-                    marginBottom: 23,
-                  }
+                  { width: searchBarWidth, marginBottom: 23 },
                 ]}
               >
                 <TextInput
+                  testID="search-input"
                   placeholder="Search..."
                   value={searchQuery}
                   placeholderTextColor="#999"
                   onChangeText={(e) => setSearchQuery(e)}
                   style={[styles(theme, width).searchInput]}
-                  cursorColor={'black'}
+                  cursorColor="black"
                   autoFocus={true}
                 />
               </Animated.View>
             )}
-            {
-              isSearchVisible ? (
-                <View style={[styles(theme, width).seachIcon, { marginTop: -25 }]}>
-                  {/* Add testID to the close button */}
-                  <TouchableOpacity onPress={toggleSearchBar} testID="close-button">
-                    <Ionicons name="close" size={25} />
-                  </TouchableOpacity>
-                </View>
-              ) : (
-                <View style={styles(theme, width).seachIcon}>
-                  {/* Add testID to the search button */}
-                  <TouchableOpacity onPress={toggleSearchBar} testID="search-button">
-                    <Ionicons name="search" size={25} />
-                  </TouchableOpacity>
-                </View>
-              )
-            }
+            {isSearchVisible ? (
+              <View style={[styles(theme, width).searchIcon, { marginTop: -25 }]}>
+                <TouchableOpacity testID="close-button" onPress={toggleSearchBar}>
+                  <Ionicons name="close" size={25} />
+                </TouchableOpacity>
+              </View>
+            ) : (
+              <View style={styles(theme, width).searchIcon}>
+                <TouchableOpacity testID="search-button" onPress={toggleSearchBar}>
+                  <Ionicons name="search" size={25} />
+                </TouchableOpacity>
+              </View>
+            )}
           </View>
-
         </View>
-
       </View>
-      <View testID = "notes-list" style={styles(theme, width).scrollerBackgroundColor}>
-        {rendering ? <NoteSkeleton /> : renderList(notes)}
+      <View testID="notes-list" style={styles(theme, width).scrollerBackgroundColor}>
+        {rendering ? <NoteSkeleton /> : renderList()}
       </View>
-      {isSortOpened && isSearchVisible == false && <View style={{
-        height: "100%",
-        width: '100%',
-        backgroundColor: isDarkmode? '#525252' : 'white',
-        position: 'absolute',
-        top: '19%',
-        borderRadius: 20,
-        padding: 20,
-      }}>
-        <Text style={{ fontSize: 20, color: isDarkmode? '#c7c7c7' : 'black', fontWeight: 600}}>Sort by</Text>
-        <View style={{ height: '50%', justifyContent: 'space-evenly', alignItems: 'center'}}>
-          <TouchableOpacity
-            onPress={() => handleSortOption({ option: 1 })}
-          >
-            <View style={[styles(theme, width).selectedSortOption, { backgroundColor: selectedSortOption === 1 ? theme.homeColor : 'none', width: 200 }]}>
-              <Text style={{ fontSize: 20, color: isDarkmode && selectedSortOption != 1 ? '#c7c7c7' : 'black' }}>Date & Time(latest)</Text>
-            </View>
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={() => handleSortOption({ option: 2 })}
-          >
-            <View style={[styles(theme, width).selectedSortOption, { backgroundColor: selectedSortOption === 2 ? theme.homeColor : 'none' }]}>
-              <Text style={{ fontSize: 20, color: isDarkmode && selectedSortOption != 2 ? '#c7c7c7' : 'black' }}>A-Z</Text>
-            </View>
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={() => handleSortOption({ option: 3 })}
-          >
-            <View style={[styles(theme, width).selectedSortOption, { backgroundColor: selectedSortOption === 3 ? theme.homeColor : 'none' }]}>
-              <Text style={{ fontSize: 20, color: isDarkmode && selectedSortOption != 3 ? '#c7c7c7' : 'black' }}>Z-A</Text>
-            </View>
-          </TouchableOpacity>
-        </View>
-      </View>}
       <NoteDetailModal
         isVisible={isModalVisible}
         onClose={() => setModalVisible(false)}
         note={selectedNote}
       />
+      {isSortOpened && !isSearchVisible && (
+        <View
+          testID="sort-options"
+          style={{
+            height: "100%",
+            width: "100%",
+            backgroundColor: isDarkmode ? "#525252" : "white",
+            position: "absolute",
+            top: "19%",
+            borderRadius: 20,
+            padding: 20,
+          }}
+        >
+          <Text style={{ fontSize: 20, color: isDarkmode ? "#c7c7c7" : "black", fontWeight: "600" }}>
+            Sort by
+          </Text>
+          <View style={{ height: "50%", justifyContent: "space-evenly", alignItems: "center" }}>
+            <TouchableOpacity onPress={() => handleSortOption({ option: 1 })}>
+              <View style={[styles(theme, width).selectedSortOption, { backgroundColor: selectedSortOption === 1 ? theme.homeColor : "none", width: 200 }]}>
+                <Text style={{ fontSize: 20, color: isDarkmode && selectedSortOption !== 1 ? "#c7c7c7" : "black" }}>
+                  Date & Time(latest)
+                </Text>
+              </View>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={() => handleSortOption({ option: 2 })}>
+              <View style={[styles(theme, width).selectedSortOption, { backgroundColor: selectedSortOption === 2 ? theme.homeColor : "none" }]}>
+                <Text style={{ fontSize: 20, color: isDarkmode && selectedSortOption !== 2 ? "#c7c7c7" : "black" }}>
+                  A-Z
+                </Text>
+              </View>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={() => handleSortOption({ option: 3 })}>
+              <View style={[styles(theme, width).selectedSortOption, { backgroundColor: selectedSortOption === 3 ? theme.homeColor : "none" }]}>
+                <Text style={{ fontSize: 20, color: isDarkmode && selectedSortOption !== 3 ? "#c7c7c7" : "black" }}>
+                  Z-A
+                </Text>
+              </View>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
     </View>
   );
 };
 
-const styles = (theme, width, color, isDarkmode) =>
+const styles = (theme, width) =>
   StyleSheet.create({
     container: {
       paddingTop: Constants.statusBarHeight - 20,
-      height: width > 500 ? height * 0.12 : height * 0.19,
       backgroundColor: theme.homeColor,
+      height: width > 500 ? height * 0.12 : height * 0.19,
     },
     pfpText: {
       fontWeight: "600",
@@ -488,6 +548,7 @@ const styles = (theme, width, color, isDarkmode) =>
     },
     scrollerBackgroundColor: {
       flex: 1,
+      width: "100%",
     },
     addButton: {
       position: "absolute",
@@ -510,33 +571,11 @@ const styles = (theme, width, color, isDarkmode) =>
       marginTop: 10,
       backgroundColor: theme.homeColor,
     },
-    dropdown: {
-      width: "100%",
-      alignItems: "center",
-      zIndex: 1000,
-      marginTop: -13,
-    },
-
-    noteContainer: {
-      justifyContent: "space-between",
-      alignItems: "center",
-      alignSelf: "center",
-      backgroundColor: theme.primaryColor,
-      marginTop: 1,
-      width: "100%",
-      flexDirection: "row",
-      height: 185,
-      paddingLeft: width * 0.03,
-      paddingRight: width * 0.03,
-      color: theme.text
-    },
-
-
     rowBack: {
       width: "100%",
       height: 140,
       alignItems: "center",
-      backgroundColor: theme.homeGray,
+      backgroundColor: theme.homeColor,
       flex: 1,
       flexDirection: "row",
       justifyContent: "space-between",
@@ -552,26 +591,51 @@ const styles = (theme, width, color, isDarkmode) =>
       top: 0,
       width: 75,
       paddingRight: 17,
-      color: theme.text
+      color: theme.text,
     },
     backRightBtnRight: {
       backgroundColor: theme.homeGray,
       width: "50%",
       right: 0,
-      color: theme.text
+      color: theme.text,
     },
     userWishContainer: {
-      marginRight: 10
+      marginRight: 10,
     },
     userName: {
-      fontWeight: '500',
+      fontWeight: "500",
       height: "50%",
     },
     toolContainer: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      alignItems: 'center',
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
       marginTop: 10,
+    },
+    publishedOrPrivateContainer: {
+      backgroundColor: "#e7e7e7",
+      height: 30,
+      width: 120,
+      borderRadius: 20,
+      marginBottom: 10,
+      flexDirection: "row",
+      justifyContent: "space-evenly",
+      alignItems: "center",
+    },
+    publishedAndSortContainer: {
+      flexDirection: "row",
+      width: width > 500 ? "20%" : "45%",
+      justifyContent: "space-between",
+    },
+    publishedTxtContainer: {
+      paddingHorizontal: 5,
+      paddingVertical: 3,
+      borderRadius: 20,
+    },
+    publishedTxt: {
+      color: "white",
+      fontSize: 10,
+      fontWeight: "600",
     },
     searchContainer: {
       right: 0,
@@ -581,7 +645,7 @@ const styles = (theme, width, color, isDarkmode) =>
       alignItems: "center",
       height: 36,
       borderRadius: 25,
-      overflow: "hidden", // Ensures the reveal is smooth
+      overflow: "hidden",
     },
     searchInput: {
       flex: 1,
@@ -591,46 +655,43 @@ const styles = (theme, width, color, isDarkmode) =>
       paddingVertical: 0,
       width: "100%",
     },
+    searchIcon: {
+      marginBottom: 10,
+    },
     searchParentContainer: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      alignItems: 'center',
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
     },
     userAccountAndPageTitle: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      width: width> 500? '13%' : "27%",
-
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      width: width > 500 ? "13%" : "27%",
     },
     pageTitle: {
       fontSize: 18,
-      fontWeight: '500'
-
+      fontWeight: "500",
     },
     lottie: {
       width: 100,
       height: 200,
     },
     resultNotFound: {
-      justifyContent: 'center',
-      alignItems: 'center'
+      justifyContent: "center",
+      alignItems: "center",
     },
     resultNotFoundTxt: {
       fontSize: 15,
-      fontWeight: '400',
+      fontWeight: "400",
     },
     selectedSortOption: {
-      // backgroundColor: theme.homeColor,
       width: width * 0.4,
-      justifyContent: 'center',
-      alignItems: 'center',
+      justifyContent: "center",
+      alignItems: "center",
       padding: 10,
       borderRadius: 10,
     },
-
-   
-
   });
 
 export default Library;

--- a/lib/screens/Library.tsx
+++ b/lib/screens/Library.tsx
@@ -574,7 +574,7 @@ const styles = (theme, width) =>
       width: "100%",
       height: 140,
       alignItems: "center",
-      backgroundColor: theme.homeColor,
+      backgroundColor: theme.homeGray,
       flex: 1,
       flexDirection: "row",
       justifyContent: "space-between",

--- a/lib/screens/Library.tsx
+++ b/lib/screens/Library.tsx
@@ -161,8 +161,8 @@ const Library = ({ navigation, route }) => {
           testID="load-more"
           onPress={handleLoadMore}
           style={{
-            paddingVertical: 10, // reduced from 20
-            paddingHorizontal: 20, // reduced from 40
+            paddingVertical: 7, // reduced from 20
+            paddingHorizontal: 12, // reduced from 40
             alignItems: "center",
             alignSelf: "center",
             borderWidth: 1,

--- a/lib/screens/Library.tsx
+++ b/lib/screens/Library.tsx
@@ -97,10 +97,10 @@ const Library = ({ navigation, route }) => {
     fetchMessages(1);
   }, [updateCounter, published]);
 
-  const fetchMessages = async (p0: number) => {
+  const fetchMessages = async (pageNum: number) => {
     try {
       // Calculate skip using the current page number
-      const skip = (p0 - 1) * limit;
+      const skip = (pageNum - 1) * limit;
       // Get userId if needed
       const userId = await user.getId();
       // Use batch-fetching with skip and limit; note we use isPrivate state
@@ -118,7 +118,7 @@ const Library = ({ navigation, route }) => {
         .sort((a, b) => new Date(b.time).getTime() - new Date(a.time).getTime());
       const finalNotes = reversed ? fetchedNotes.reverse() : fetchedNotes;
   
-      if (p0 === 1) {
+      if (pageNum === 1) {
         setNotes(finalNotes);
       } else {
         setNotes((prev) => [...prev, ...finalNotes]);
@@ -150,8 +150,8 @@ const Library = ({ navigation, route }) => {
   const renderFooter = () => {
     if (isLoadingMore) {
       return (
-        <View style={{ padding: 20, alignItems: "center" }}>
-          <ActivityIndicator size="large" color={theme.text} />
+        <View  style={{ paddingVertical: 50, alignItems: "center", marginBottom: 100 }}>
+          <ActivityIndicator size="small" color={theme.text} />
         </View>
       );
     }
@@ -161,14 +161,13 @@ const Library = ({ navigation, route }) => {
           testID="load-more"
           onPress={handleLoadMore}
           style={{
-            paddingVertical: 20,
-            paddingHorizontal: 40,
+            paddingVertical: 10, // reduced from 20
+            paddingHorizontal: 20, // reduced from 40
             alignItems: "center",
             alignSelf: "center",
             borderWidth: 1,
-            borderColor: "white",
-            borderRadius: 10,
-            marginVertical: 10,
+            borderRadius: 8,
+            marginVertical: 4, // reduced from 8
             backgroundColor: theme.homeColor,
           }}
         >
@@ -217,6 +216,7 @@ const Library = ({ navigation, route }) => {
   };
 
   const renderList = (notes: Note[]) => {
+    // Filter notes if there's a search query.
     const filteredNotes = searchQuery
       ? notes.filter((note) => {
           const lowerCaseQuery = searchQuery.toLowerCase();
@@ -228,26 +228,30 @@ const Library = ({ navigation, route }) => {
           );
         })
       : notes;
-  
-    // Apply sorting based on selectedSortOption
-    filteredNotes.sort((a, b) => {
-      if (selectedSortOption === 1) {
-        return new Date(b.time).getTime() - new Date(a.time).getTime();
-      } else if (selectedSortOption === 2) {
-        return a.title.toLowerCase().localeCompare(b.title.toLowerCase());
-      } else if (selectedSortOption === 3) {
-        return b.title.toLowerCase().localeCompare(a.title.toLowerCase());
-      }
-      return 0;
-    });
-  
+    
+    // Only apply sort if there's an active search query.
+    // Otherwise, display the notes in the natural order they are stored.
+    const displayNotes = searchQuery
+      ? filteredNotes.sort((a, b) => {
+          // (Your sorting logic here if needed when filtering)
+          if (selectedSortOption === 1) {
+            return new Date(b.time).getTime() - new Date(a.time).getTime();
+          } else if (selectedSortOption === 2) {
+            return a.title.toLowerCase().localeCompare(b.title.toLowerCase());
+          } else if (selectedSortOption === 3) {
+            return b.title.toLowerCase().localeCompare(a.title.toLowerCase());
+          }
+          return 0;
+        })
+      : filteredNotes;
+    
     return published && (
-      filteredNotes.length > 0 ? (
+      displayNotes.length > 0 ? (
         <SwipeListView
-          data={filteredNotes}
+          data={displayNotes}
           renderItem={renderItem}
           keyExtractor={(item) => item.id}
-          contentContainerStyle={{ paddingBottom: 150 }}
+          contentContainerStyle={{ paddingBottom: isLoadingMore ? 50 : 150 }}
           ListFooterComponent={renderFooter}
         />
       ) : (
@@ -263,6 +267,7 @@ const Library = ({ navigation, route }) => {
       )
     );
   };
+  
 
   const renderItem = (data: any) => {
     const item = data.item;

--- a/lib/screens/Library.tsx
+++ b/lib/screens/Library.tsx
@@ -158,23 +158,22 @@ const Library = ({ navigation, route }) => {
     if (hasMore) {
       return (
         <TouchableOpacity
-          testID="load-more"
-          onPress={handleLoadMore}
-          style={{
-            paddingVertical: 7, // reduced from 20
-            paddingHorizontal: 12, // reduced from 40
-            alignItems: "center",
-            alignSelf: "center",
-            borderWidth: 1,
-            borderRadius: 8,
-            marginVertical: 4, // reduced from 8
-            backgroundColor: theme.homeColor,
-          }}
-        >
-          <Text testID="load-more-button" style={{ color: theme.text, fontSize: 16, fontWeight: "600" }}>
-            Load More
-          </Text>
-        </TouchableOpacity>
+        testID="load-more"
+        onPress={handleLoadMore}
+        style={{
+          paddingVertical: 20,
+          width: "65%",
+          alignItems: "center",
+          alignSelf: "center",
+          borderRadius: 20,
+          marginVertical: 4, // reduced from 8
+          backgroundColor: theme.homeColor,
+        }}
+      >
+        <Text testID="load-more-button" style={{ color: theme.text, fontSize: 16, fontWeight: "400" }}>
+          Load More
+        </Text>
+      </TouchableOpacity>
       );
     }
     return (

--- a/lib/screens/Library.tsx
+++ b/lib/screens/Library.tsx
@@ -278,7 +278,6 @@ const Library: React.FC = ({ navigation, route }) => {
     );
   };
 
-  // Render list with optional sorting and filtering
   const renderList = () => {
     let sortedNotes = [...filteredNotes];
     sortedNotes.sort((a, b) => {

--- a/lib/utils/api_calls.ts
+++ b/lib/utils/api_calls.ts
@@ -63,6 +63,44 @@ static async fetchMessages(
     throw error;
   }
 }
+
+static async fetchMessagesBatch(
+  global: boolean,
+  published: boolean,
+  userId: string,
+  limit = 20,
+  skip = 0
+): Promise<any[]> {
+try {
+  const url = `${API_BASE_URL}query?limit=${limit}&skip=${skip}`;
+  const headers = {
+    "Content-Type": "application/json",
+  };
+
+  let body: { type: string; published?: boolean; creator?: string } = {
+    type: "message",
+  };
+
+  if (global) {
+    body = { type: "message" };
+  } else if (published) {
+    body = { type: "message", published: true };
+  } else {
+    body = { type: "message", creator: userId };
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const data = await response.json();
+  return data;
+} catch (error) {
+  console.error("Error fetching messages:", error);
+  throw error;
+}
+}
  /**
    * Fetches user data from Firestore first, then the API if Firestore data is not found.
    * @param {string} uid - The UID of the user.


### PR DESCRIPTION
fixes #221 

What was changed
The library page now loading 20 notes at a time and the user is able to click a "load more" button if they would like to view more notes. 
Why was it changed
Before loading all the notes at one time was causing performance issues. 

How was it changed
Created an api call to fetch only 20 at a time. This is called In the library page and there is supporting logic for when the user clicks the "Load More" button, this also displays a message at the end of the note scroll to notify the user there are no more Notes left. 