### PR TITLE
User Onboarding Tutorial 

### DIFF
--- a/__tests__/Library.test.tsx
+++ b/__tests__/Library.test.tsx
@@ -110,6 +110,7 @@ jest.mock('../lib/components/ThemeProvider', () => ({
   })),
 }));
 
+
 // Mock expo-location module with TypeScript type support
 jest.mock('expo-location', () => ({
   getForegroundPermissionsAsync: jest.fn(),

--- a/lib/onboarding/TooltipComponent.tsx
+++ b/lib/onboarding/TooltipComponent.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+
+const TooltipContent = ({ 
+  message, 
+  onPressOk, 
+  onSkip 
+}) => {
+  return (
+    <View style={styles.container}>
+      {/* Skip Button in top-right corner */}
+      <TouchableOpacity style={styles.skipButton} onPress={onSkip}>
+        <Text style={styles.skipText}>Skip Tutorial</Text>
+      </TouchableOpacity>
+
+      {/* Tutorial message */}
+      <Text style={styles.message}>{message}</Text>
+
+      {/* "Okay" button */}
+      <TouchableOpacity style={styles.okButton} onPress={onPressOk}>
+        <Text style={styles.okText}>Okay</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    borderRadius: 12,
+    backgroundColor: '#FFF',
+    minWidth: 200,
+    alignItems: 'center',
+    // iOS shadow
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    // Android elevation
+    elevation: 5,
+  },
+  skipButton: {
+    position: 'absolute',
+    top: 5,
+    right: 8,
+    padding: 4,
+  },
+  skipText: {
+    color: '#007AFF',
+    fontWeight: 'bold',
+    fontSize: 13,
+  },
+  message: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginTop: 17, // Increased margin to push the message lower
+    marginBottom: 18,
+    textAlign: 'center',
+    color: '#333',
+  },
+  okButton: {
+    marginTop: 9,
+    backgroundColor: '#007AFF',
+    paddingVertical: 11,
+    paddingHorizontal: 20,
+    borderRadius: 6,
+  },
+  okText: {
+    color: '#FFF',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});
+
+export default TooltipContent;

--- a/lib/onboarding/TooltipComponent.tsx
+++ b/lib/onboarding/TooltipComponent.tsx
@@ -1,22 +1,23 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme } from '../components/ThemeProvider';
 
 const TooltipContent = ({ 
   message, 
   onPressOk, 
   onSkip 
 }) => {
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
+
   return (
     <View style={styles.container}>
-      {/* Skip Button in top-right corner */}
       <TouchableOpacity style={styles.skipButton} onPress={onSkip}>
         <Text style={styles.skipText}>Skip Tutorial</Text>
       </TouchableOpacity>
 
-      {/* Tutorial message */}
       <Text style={styles.message}>{message}</Text>
 
-      {/* "Okay" button */}
       <TouchableOpacity style={styles.okButton} onPress={onPressOk}>
         <Text style={styles.okText}>Okay</Text>
       </TouchableOpacity>
@@ -24,51 +25,43 @@ const TooltipContent = ({
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    padding: 16,
-    borderRadius: 12,
-    backgroundColor: '#FFF',
-    minWidth: 200,
-    alignItems: 'center',
-    // iOS shadow
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.2,
-    // Android elevation
-    elevation: 5,
-  },
-  skipButton: {
-    position: 'absolute',
-    top: 5,
-    right: 8,
-    padding: 4,
-  },
-  skipText: {
-    color: '#007AFF',
-    fontWeight: 'bold',
-    fontSize: 13,
-  },
-  message: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginTop: 17, // Increased margin to push the message lower
-    marginBottom: 18,
-    textAlign: 'center',
-    color: '#333',
-  },
-  okButton: {
-    marginTop: 9,
-    backgroundColor: '#007AFF',
-    paddingVertical: 11,
-    paddingHorizontal: 20,
-    borderRadius: 6,
-  },
-  okText: {
-    color: '#FFF',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-});
+const createStyles = (theme) =>
+  StyleSheet.create({
+    container: {
+      backgroundColor: theme.tooltipBackground || '#FFF',
+      minWidth: 200,
+      alignItems: 'center',
+    },
+    skipButton: {
+      position: 'absolute',
+      top: 5,
+      right: 8,
+    },
+    skipText: {
+      color: theme.homeColor || '#007AFF',
+      fontWeight: 'bold',
+      fontSize: 13,
+    },
+    message: {
+      fontSize: 16,
+      fontWeight: '600',
+      marginVertical: 30,
+      textAlign: 'center',
+      color: theme.text || '#333',
+    },
+    okButton: {
+      marginTop: 20,
+      backgroundColor: theme.homeColor || '#007AFF',
+      // Minimal padding so the text isn't cramped
+      paddingVertical: 6,
+      paddingHorizontal: 12,
+      borderRadius: 6,
+    },
+    okText: {
+      color: '#FFF',
+      fontSize: 16,
+      fontWeight: '600',
+    },
+  });
 
 export default TooltipContent;

--- a/lib/screens/HomeScreen.tsx
+++ b/lib/screens/HomeScreen.tsx
@@ -38,7 +38,8 @@ import { green } from "react-native-reanimated/lib/typescript/Colors";
 import { toogleAddNoteState } from "../../redux/slice/AddNoteStateSlice";
 import { useSelector, useDispatch } from 'react-redux'
 import { defaultTextFont } from "../../styles/globalStyles";
-
+import Tooltip from "react-native-walkthrough-tooltip";
+import TooltipContent from "../onboarding/TooltipComponent";
 const { width, height } = Dimensions.get("window");
 const user = User.getInstance();
 
@@ -479,6 +480,23 @@ const handleSortOption = ({ option }) => {
     });
   }, [notes, searchQuery]);
 
+  const [userTutorial, setUserTutorial] = useState<boolean | null>(null);
+  const [accountTip, setAccontTip] = useState(false); // Start false
+  const [filterToolTip, setFilterToolTip] = useState(false); 
+  const [searchTip, setSearchTip] = useState(false); 
+  const [pubPrivTip, setPubPrivTip] = useState(false); 
+
+  
+  useEffect(() => {
+    User.getHasDoneTutorial("Explore").then(tutorialDone => {
+      setUserTutorial(tutorialDone);
+      if (!tutorialDone) {
+        setAccontTip(true); // Enable tooltips only if user hasn't seen them
+      }
+    });
+  }, []);
+
+
   return (
     <View style={{ flex: 1, backgroundColor : isDarkmode? 'black' : '#e4e4e4'}}>
       <StatusBar translucent backgroundColor="transparent" />
@@ -495,6 +513,27 @@ const handleSortOption = ({ option }) => {
             }}
           >
             <View style={styles(theme, width).userAccountAndPageTitle}>
+            <Tooltip
+                topAdjustment={Platform.OS === 'android' ? -StatusBar.currentHeight : 0}
+                showChildInTooltip = {false}
+                isVisible={accountTip}
+                content={
+                <TooltipContent
+                      message="View Account Here!"
+                      onPressOk={() => {
+                        setAccontTip(false);
+                        setSearchTip(true);
+                    }}
+                    onSkip={() => {
+                      // Disable all tutorial tips when Skip is pressed
+                      setAccontTip(false);
+                      setSearchTip(false);
+                      setFilterToolTip(false);
+                    }}
+                  />
+              }
+              placement="bottom"
+      >
               <TouchableOpacity testID="user-account"
                 style={[
                   styles(theme, width).userPhoto,
@@ -510,6 +549,7 @@ const handleSortOption = ({ option }) => {
               >
                 <Text style={styles(theme, width).pfpText}>{userInitials}</Text>
               </TouchableOpacity>
+            </Tooltip>
               <Text style={styles(theme, width).pageTitle}>Notes</Text>
             </View>
 
@@ -526,6 +566,26 @@ const handleSortOption = ({ option }) => {
           {
             !isSearchVisible && (
             <View style={styles(theme, width).publishedAndSortContainer}>
+          <Tooltip
+              topAdjustment={Platform.OS === 'android' ? -StatusBar.currentHeight : 0}
+              showChildInTooltip = {false}
+              isVisible={pubPrivTip}
+              content={
+              <TooltipContent
+                message="Switch between public and private notes"
+                  onPressOk={() => {
+                    setPubPrivTip(false);
+                }}
+                onSkip={() => {
+                  // Disable all tutorial tips when Skip is pressed
+                  setAccontTip(false);
+                  setSearchTip(false);
+                  setFilterToolTip(false);
+                }}
+            />
+          }
+          placement="bottom"
+          >
               <View style={styles(theme, width).publishedOrPrivateContainer}>
                 <Pressable onPress={() => {
                   setIsPrivate(false);
@@ -544,13 +604,37 @@ const handleSortOption = ({ option }) => {
                   </View>
                 </Pressable>
               </View>
+              </Tooltip>
               <View>
                 {
-                  !isSortOpened ? (<TouchableOpacity testID="sort-button"
+                  !isSortOpened ? (
+                    <Tooltip
+                    topAdjustment={Platform.OS === 'android' ? -StatusBar.currentHeight : 0}
+                    isVisible={filterToolTip}
+                    content={
+                    <TooltipContent
+                      message="Filter notes"
+                        onPressOk={() => {
+                          setFilterToolTip(false);
+                          setPubPrivTip(true);
+                      }}
+                      onSkip={() => {
+                        // Disable all tutorial tips when Skip is pressed
+                        setAccontTip(false);
+                        setSearchTip(false);
+                        setFilterToolTip(false);
+                      }}
+                  />
+                }
+                placement="bottom"
+                >
+                <TouchableOpacity testID="sort-button"
                     onPress={handleSort}
                   >
+      
                     <MaterialIcons name='sort' size={30} />
-                  </TouchableOpacity>)
+                  </TouchableOpacity>
+                  </Tooltip>)
                     : (
                       <TouchableOpacity
                         onPress={handleSort}
@@ -599,7 +683,28 @@ const handleSortOption = ({ option }) => {
               ) : (
                 <View style={styles(theme, width).searchIcon}>
                   <TouchableOpacity testID="searchButton" onPress={toggleSearchBar}>
+                  <Tooltip
+                      topAdjustment={Platform.OS === 'android' ? -StatusBar.currentHeight : 0}
+                      isVisible={searchTip}
+                      content={
+                      <TooltipContent
+                        message="Search Notes!"
+                          onPressOk={() => {
+                            setSearchTip(false);
+                            setFilterToolTip(true);
+                        }}
+                        onSkip={() => {
+                          // Disable all tutorial tips when Skip is pressed
+                          setAccontTip(false);
+                          setSearchTip(false);
+                          setFilterToolTip(false);
+                        }}
+                    />
+                  }
+                  placement="bottom"
+                  >
                     <Ionicons name='search' size={25} />
+                  </Tooltip>
                   </TouchableOpacity>
                 </View>
               )

--- a/lib/screens/Library.tsx
+++ b/lib/screens/Library.tsx
@@ -35,7 +35,8 @@ import NotesComponent from "../components/NotesComponent";
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import LottieView from 'lottie-react-native';
 import { defaultTextFont } from "../../styles/globalStyles";
-
+import Tooltip from 'react-native-walkthrough-tooltip';
+import TooltipContent from "../onboarding/TooltipComponent";
 const user = User.getInstance();
 const { width, height } = Dimensions.get("window");
 
@@ -353,6 +354,19 @@ const Library = ({ navigation, route }) => {
     setIsSortOpened(false);
   };
 
+    const [userTutorial, setUserTutorial] = useState(User.getHasDoneTutorial("Explore")); //set to false initially.
+  
+    User.getHasDoneTutorial("Explore").then(userTutorial => {
+      console.log("USER TUTORIAL: " + userTutorial); // This will log true or false
+    });
+    
+    const [accountTip, setAccontTip] = useState(true); //2nd tip
+    const [filterToolTip, setFilterToolTip] = useState(false); //this is the first tip
+    const [searchTip, setSearchTip] = useState(false); //2nd tip
+
+
+  
+
   return (
     <View testID="Library" style={{ flex: 1, backgroundColor: isDarkmode ? 'black' : '#e4e4e4' }}>
       <StatusBar translucent backgroundColor="transparent" />
@@ -369,6 +383,26 @@ const Library = ({ navigation, route }) => {
             }}
           >
             <View style={styles(theme, width).userAccountAndPageTitle}>
+            <Tooltip
+                topAdjustment={Platform.OS === 'android' ? -StatusBar.currentHeight : 0}
+                isVisible={accountTip}
+                content={
+                <TooltipContent
+                      message="View Account Here!"
+                      onPressOk={() => {
+                        setAccontTip(false);
+                        setSearchTip(true);
+                    }}
+                    onSkip={() => {
+                      // Disable all tutorial tips when Skip is pressed
+                      setAccontTip(false);
+                      setSearchTip(false);
+                      setFilterToolTip(false);
+                    }}
+                  />
+              }
+              placement="bottom"
+      >
               <TouchableOpacity 
                 testID="account-page"
                 style={[
@@ -385,6 +419,7 @@ const Library = ({ navigation, route }) => {
               >
                 <Text style={styles(theme, width).pfpText}>{userInitials}</Text>
               </TouchableOpacity>
+            </Tooltip>
               <Text style={styles(theme, width).pageTitle}>Library</Text>
             </View>
   
@@ -398,10 +433,30 @@ const Library = ({ navigation, route }) => {
         <View testID="Filter" style={[styles(theme, width).toolContainer, { marginHorizontal: 20 }]}>
           {
             !isSearchVisible && (
+              <Tooltip
+              topAdjustment={Platform.OS === 'android' ? -StatusBar.currentHeight : 0}
+              isVisible={filterToolTip}
+              content={
+              <TooltipContent
+                message="Filter notes"
+                  onPressOk={() => {
+                    setFilterToolTip(false);
+                }}
+                onSkip={() => {
+                  // Disable all tutorial tips when Skip is pressed
+                  setAccontTip(false);
+                  setSearchTip(false);
+                  setFilterToolTip(false);
+                }}
+            />
+          }
+          placement="bottom"
+          >
               <View>
                 {
                   !isSortOpened ? (
                     <TouchableOpacity onPress={handleSort}>
+        
                       <MaterialIcons name='sort' size={30} />
                     </TouchableOpacity>
                   ) : (
@@ -411,6 +466,7 @@ const Library = ({ navigation, route }) => {
                   )
                 }
               </View>
+            </Tooltip>
             )
           }
           <View testID="SearchBar" style={[styles(theme, width).searchParentContainer, { width: isSearchVisible ? '95%' : 40 }]}>
@@ -442,7 +498,28 @@ const Library = ({ navigation, route }) => {
               ) : (
                 <View style={styles(theme, width).seachIcon}>
                   <TouchableOpacity onPress={toggleSearchBar} testID="search-button">
+                  <Tooltip
+                      topAdjustment={Platform.OS === 'android' ? -StatusBar.currentHeight : 0}
+                      isVisible={searchTip}
+                      content={
+                      <TooltipContent
+                        message="Search Notes!"
+                          onPressOk={() => {
+                            setSearchTip(false);
+                            setFilterToolTip(true);
+                        }}
+                        onSkip={() => {
+                          // Disable all tutorial tips when Skip is pressed
+                          setAccontTip(false);
+                          setSearchTip(false);
+                          setFilterToolTip(false);
+                        }}
+                    />
+                  }
+                  placement="bottom"
+                  >
                     <Ionicons name="search" size={25} />
+                  </Tooltip>
                   </TouchableOpacity>
                 </View>
               )

--- a/lib/screens/mapPage/ExploreScreen.js
+++ b/lib/screens/mapPage/ExploreScreen.js
@@ -347,7 +347,7 @@ const ExploreScreen = () => {
   <Tooltip
         isVisible={scrollTip}
         showChildInTooltip = {false}
-        topAdjustment={Platform.OS === 'android' ? -StatusBar.currentHeight : -250}
+        topAdjustment={Platform.OS === 'android' ? -250 : -250}
         content={
           <TooltipContent
             message="Scroll here!"

--- a/lib/screens/mapPage/ExploreScreen.js
+++ b/lib/screens/mapPage/ExploreScreen.js
@@ -18,13 +18,15 @@ import * as Location from "expo-location";
 import NoteDetailModal from "./NoteDetailModal";
 import { formatToLocalDateString } from "../../components/time";
 import Ionicons from "react-native-vector-icons/Ionicons";
-
+import { User } from "../../models/user_class";
 import { mapDarkStyle, mapStandardStyle } from "./mapData";
 import ApiService from "../../utils/api_calls";
 import Constants from "expo-constants";
 import { useTheme } from "../../components/ThemeProvider";
 import { MapNotesComponent } from "../../components/MapNotesComponent";
-
+import Tooltip from 'react-native-walkthrough-tooltip';
+import TooltipContent from "../../onboarding/TooltipComponent";
+import SkipButton from "../../onboarding/SkipTutorial";
 const { width } = Dimensions.get("window");
 const CARD_HEIGHT = 220;
 const CARD_WIDTH = width * 0.8;
@@ -254,7 +256,19 @@ const ExploreScreen = () => {
     }
   };
 
-  const shouldShowLoadMore = !searchResults && hasMore && currentIndex >= page * LIMIT - 1;
+  const shouldShowLoadMore = !searchResults && hasMore && currentIndex >= page * LIMIT - 1;  
+
+  /* CHECKING IF USER HAS DONE TUTORIAL */ 
+  const user = User.getInstance();
+  const [userTutorial, setUserTutorial] = useState(User.getHasDoneTutorial("Explore")); //set to false initially.
+
+  User.getHasDoneTutorial("Explore").then(userTutorial => {
+    console.log("USER TUTORIAL: " + userTutorial); // This will log true or false
+  });
+
+  const [searchToolTip, setSearchToolTip] = useState(true); //this is the first tip
+  const [scrollTip, setScrollTip] = useState(false); //2nd tip
+  const [tutorialActive, setTutorialActive] = useState(true); //2nd tip
 
   return (
     <View style={styles.container} testID="Explore">
@@ -292,6 +306,7 @@ const ExploreScreen = () => {
             style={{ marginRight: 9 }}
           />
         </TouchableOpacity>
+    
         <TextInput
           returnKeyType="done"
           placeholder="Search here"
@@ -301,9 +316,55 @@ const ExploreScreen = () => {
           onChangeText={setSearchQuery}
           onSubmitEditing={handleSearch}
         />
-        <Ionicons name="search" size={25} onPress={handleSearch} color={theme.text} />
-      </View>
+        <Tooltip
+        topAdjustment={Platform.OS === 'android' ? -StatusBar.currentHeight : 0}
+        isVisible={searchToolTip}
+        content={
+          <TooltipContent
+            message="Search here!"
+            onPressOk={() => {
+              console.log("Okay pressed");
+              setSearchToolTip(false);
+              setScrollTip(true);
+            }}
+            onSkip={() => {
+              // Disable all tutorial tips when Skip is pressed
+              setTutorialActive(false);
+              setSearchToolTip(false);
+              setScrollTip(false);
+            }}
+          />
+        }
+        placement="bottom"
+        onClose={() => setSearchToolTip(false)}
+      >
+      <Ionicons name="search" size={25} onPress={handleSearch} color={theme.text} />
+    </Tooltip>
 
+  </View>
+
+
+  <Tooltip
+        isVisible={scrollTip}
+        showChildInTooltip = {false}
+        topAdjustment={Platform.OS === 'android' ? -StatusBar.currentHeight : -250}
+        content={
+          <TooltipContent
+            message="Scroll here!"
+            onPressOk={() => {
+              setScrollTip(false);
+            }}
+            onSkip={() => {
+              // Disable all tutorial tips when Skip is pressed
+              setTutorialActive(false);
+              setSearchToolTip(false);
+              setScrollTip(false);
+            }}
+          />
+        }
+        placement="top"
+        onClose={() => setSearchToolTip(false)}
+      >
       <Animated.ScrollView
         ref={_scrollView}
         testID="cardScrollView"
@@ -320,6 +381,7 @@ const ExploreScreen = () => {
           useNativeDriver: true,
         })}
       >
+  
         {state.markers.map((marker, index) => (
           <MapNotesComponent key={index} index={index} marker={marker} onViewNote={onViewNote} />
         ))}
@@ -340,6 +402,8 @@ const ExploreScreen = () => {
           </View>
         )}
       </Animated.ScrollView>
+    </Tooltip>
+          
 
       <NoteDetailModal isVisible={isModalVisible} onClose={() => setModalVisible(false)} note={selectedNote} />
     </View>


### PR DESCRIPTION
fixes #200 

What changed:

First Tim users now get tips and tricks about the app as they move through our different pages.

Why was this changed?

This will clarify how to use the app to new users and this is a feature we see in almost all software today. 

How it was changed:

I have imported a tooltip library which wraps a particular component I use useState variables for each page that keeps track of what tooltips have been seen. Once all have been seen the user will no longer see these tips because I have an async storage function in the user_class that allows me to set True on wether they have done the tutorial for that page or not.

WHAT STILL NEEDS TO BE DONE:

Tests
Tutorial for create note screen and home page.