### PR TITLE
Keyboard close on EditNoteScreen

### DIFF
--- a/__tests__/EditNoteTest.test.tsx
+++ b/__tests__/EditNoteTest.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react-native';
+import { Keyboard } from 'react-native';
+import EditNoteScreen from '../lib/screens/EditNoteScreen';
+import moxios from 'moxios';
+import { AddNoteProvider } from '../lib/context/AddNoteContext';
+import { Provider } from 'react-redux';
+import { store } from '../redux/store/store';
+
+jest.mock('expo-font', () => {
+  const actual = jest.requireActual('expo-font');
+  return {
+    ...actual,
+    loadedNativeFonts: [],                   // forEach exists
+    loadAsync: jest.fn().mockResolvedValue(undefined),
+    isLoaded: jest.fn().mockReturnValue(true),
+  };
+});
+
+jest.mock('../lib/components/ThemeProvider', () => ({
+  useTheme: () => ({
+    theme: { text: '#000', homeColor: '#fff', backgroundColor: '#fff' },
+  }),
+}));
+
+jest.mock('react-native-keyboard-aware-scroll-view', () => ({
+  KeyboardAwareScrollView: ({ children }: any) => children,
+}));
+
+jest.mock('@10play/tentap-editor', () => ({
+  RichText: () => null,
+  Toolbar: () => null,
+  useEditorBridge: () => ({
+    getHTML: jest.fn().mockResolvedValue(''),
+    setContent: jest.fn(),
+    injectCSS: jest.fn(),
+    focus: jest.fn(),
+    blur: jest.fn(),
+  }),
+  DEFAULT_TOOLBAR_ITEMS: [],
+}));
+
+jest.mock('expo-location', () => ({
+  requestForegroundPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+  getCurrentPositionAsync: jest.fn().mockResolvedValue({ coords: { latitude: 0, longitude: 0 } }),
+}));
+
+jest.mock('firebase/auth', () => ({
+  getAuth: jest.fn(),
+  initializeAuth: jest.fn(),
+  getReactNativePersistence: jest.fn(),
+  onAuthStateChanged: jest.fn(),
+}));
+jest.mock('firebase/database', () => ({ getDatabase: jest.fn() }));
+jest.mock('react-native/Libraries/Image/Image', () => ({
+  ...jest.requireActual('react-native/Libraries/Image/Image'),
+  resolveAssetSource: jest.fn(),
+}));
+jest.mock('redux-persist', () => ({
+  ...jest.requireActual('redux-persist'),
+  persistReducer: jest.fn((_, reducers) => reducers),
+}));
+
+// --- Capture Keyboard listeners ---
+const keyboardListeners: Record<string, Function> = {};
+beforeAll(() => {
+  jest.spyOn(Keyboard, 'addListener').mockImplementation((event, cb) => {
+    keyboardListeners[event] = cb;
+    return { remove: jest.fn() };
+  });
+});
+
+// --- Navigation mock ---
+const navigationMock = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  addListener: jest.fn().mockImplementation((_evt: string, cb: Function) => {
+    // Immediately return unsubscribe
+    return () => {};
+  }),
+  canGoBack: jest.fn().mockReturnValue(true),
+};
+
+const fakeNote = {
+  id: '1',
+  title: 'Test Title',
+  time: new Date().toISOString(),
+  text: '<p>Hello World</p>',
+  tags: ['tag1'],
+  media: [],
+  audio: [],
+  published: false,
+  latitude: '0',
+  longitude: '0',
+};
+
+beforeEach(() => {
+  moxios.install();
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  moxios.uninstall();
+});
+
+describe('EditNoteScreen', () => {
+  it('renders without crashing', () => {
+    const onSaveMock = jest.fn();
+    render(
+      <Provider store={store}>
+        <AddNoteProvider>
+          <EditNoteScreen
+            navigation={navigationMock as any}
+            route={{ params: { note: fakeNote, onSave: onSaveMock } }}
+          />
+        </AddNoteProvider>
+      </Provider>
+    );
+    expect(screen.getByTestId('EditNoteScreen')).toBeTruthy();
+  });
+
+  it('renders the done button when keyboard is shown', () => {
+    const onSaveMock = jest.fn();
+    render(
+      <Provider store={store}>
+        <AddNoteProvider>
+          <EditNoteScreen
+            navigation={navigationMock as any}
+            route={{ params: { note: fakeNote, onSave: onSaveMock } }}
+          />
+        </AddNoteProvider>
+      </Provider>
+    );
+
+    // Simulate keyboardDidShow
+    act(() => {
+      keyboardListeners['keyboardDidShow']({ endCoordinates: { height: 300 } });
+    });
+
+    expect(screen.getByTestId('doneButton')).toBeTruthy();
+  });
+  
+});

--- a/lib/screens/EditNoteScreen.tsx
+++ b/lib/screens/EditNoteScreen.tsx
@@ -322,7 +322,7 @@ const EditNoteScreen = ({ route, navigation }) => {
 
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={{ flex: 1 }} testID="EditNoteScreen">
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "padding" : "height"}
         style={{ flex: 1 }}
@@ -409,7 +409,7 @@ const EditNoteScreen = ({ route, navigation }) => {
 
         {/* Floating toolbar above the keyboard */}
         {Platform.OS === "android" && (
-          <View style={styles.toolbar} testID="RichEditor">
+          <View style={styles.toolbar} testID="Toolbar">
             <Toolbar editor={editor} items={DEFAULT_TOOLBAR_ITEMS} />
           </View>
         )}
@@ -422,14 +422,12 @@ const EditNoteScreen = ({ route, navigation }) => {
           </View>
     )}
      
-        {/* Always-on iOS toolbar */}
-        {Platform.OS === "ios" && (
-          <Toolbar editor={editor} items={DEFAULT_TOOLBAR_ITEMS} />
-        )}
-        
 
-   
+     {Platform.OS === "ios" && (
+    <Toolbar editor={editor} items={DEFAULT_TOOLBAR_ITEMS} />
+)}
 
+  
         {/* Loading spinner */}
         <LoadingModal visible={isUpdating} />
       </KeyboardAvoidingView>
@@ -442,7 +440,7 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderColor: "#ccc",
     zIndex: 10,            // make sure it floats above the keyboard toolbar
-    marginTop: 555,
+    marginTop: Platform.OS === "ios" ? 500 : 555,
     marginLeft: 350
   },
   doneText: {
@@ -452,19 +450,14 @@ const styles = StyleSheet.create({
     marginRight: 0,
   },
   toolbar: {
-    position: 'absolute', // Keep toolbar at the bottom of the screen
-    bottom: 27,
-    width: '100%', // Full-width toolbar
-    justifyContent: 'center', // Center items in the toolbar
-    zIndex: 10, // Ensure it stays above other elements
-    ...Platform.select({
-      android: {
-        height: 50,
-      },
-      ios: {
-        height: 70,
-      },
-    }),
+    position: "absolute",
+    bottom: 27,         // same as your floating toolbar
+    left: 0,
+    right: 0,
+    height: 70,         // or whatever your toolbar’s height is
+    justifyContent: "center",
+    paddingHorizontal: 10,
+    zIndex: 10,
   },
 });
 

--- a/lib/screens/EditNoteScreen.tsx
+++ b/lib/screens/EditNoteScreen.tsx
@@ -420,14 +420,13 @@ const EditNoteScreen = ({ route, navigation }) => {
           </View>
           
     )}
-        </KeyboardAwareScrollView>
-
-
-        {Platform.OS === "android" && (
+           {Platform.OS === "android" && (
           <View style={styles.toolbar} testID="Toolbar">
             <Toolbar editor={editor} items={DEFAULT_TOOLBAR_ITEMS} />
           </View>
         )}
+        </KeyboardAwareScrollView>
+
 
 
         {/* Loading spinner */}
@@ -446,7 +445,7 @@ const styles = StyleSheet.create({
     borderColor: "#ccc",
     zIndex: 10,            // float above the keyboard toolbar
     // these % values are relative to the **parent** container’s dimensions
-    marginTop: Platform.OS === "ios" ? "135%" : "130%",
+    marginTop: Platform.OS === "ios" ? "135%" : "137%",
     marginLeft: "83%",
   },
   

--- a/lib/screens/EditNoteScreen.tsx
+++ b/lib/screens/EditNoteScreen.tsx
@@ -81,18 +81,20 @@ const EditNoteScreen = ({ route, navigation }) => {
     };
   }, []);
 //find the keyboards height
-  useEffect(() => {
-    const showSub = Keyboard.addListener("keyboardDidShow", e => {
-      setKeyboardHeight(e.endCoordinates.height);
-    });
-    const hideSub = Keyboard.addListener("keyboardDidHide", () => {
-      setKeyboardHeight(0);
-    });
-    return () => {
-      showSub.remove();
-      hideSub.remove();
-    };
-  }, []);
+useEffect(() => {
+  const showSub = Keyboard.addListener("keyboardDidShow", ({ endCoordinates }) => {
+    setKeyboardVisible(true);
+    setKeyboardHeight(endCoordinates.height);
+  });
+  const hideSub = Keyboard.addListener("keyboardDidHide", () => {
+    setKeyboardVisible(false);
+    setKeyboardHeight(0);
+  });
+  return () => {
+    showSub.remove();
+    hideSub.remove();
+  };
+}, []);
 
   const handleDonePress = () => {
     if (editor?.blur) editor.blur();   // blur the rich-text editor

--- a/lib/screens/EditNoteScreen.tsx
+++ b/lib/screens/EditNoteScreen.tsx
@@ -464,7 +464,7 @@ const styles = StyleSheet.create({
     zIndex: 10, // Ensure it stays above other elements
     ...Platform.select({
       android: {
-        height: 70,
+        height: 60,
       },
       ios: {
         height: 50,

--- a/lib/screens/EditNoteScreen.tsx
+++ b/lib/screens/EditNoteScreen.tsx
@@ -29,14 +29,12 @@ import { useAddNoteContext } from "../context/AddNoteContext";
 import { useDispatch } from "react-redux";
 import { toogleAddNoteState } from "../../redux/slice/AddNoteStateSlice";
 import { useFocusEffect } from "@react-navigation/native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 
 const user = User.getInstance();
 const EditNoteScreen = ({ route, navigation }) => {
   const { note, onSave } = route.params;
   const [keyboardVisible, setKeyboardVisible] = useState(false);
-  const insets = useSafeAreaInsets()
 
   const [title, setTitle] = useState(note.title || "Untitled");
   const [time, setTime] = useState(new Date(note.time));


### PR DESCRIPTION
Fix: #252 

What was changed
There is now a done button on the editNoteScreen for when the keyboard is up allowing the user to de-toggle the keyboard.

Why was it changed
Before if the user put their keyboard up there was no way for them to get it down. This created an unpleasant user experience.

How was it changed
Using much of the same logic in AddNoteScreen it keeps track if the keyboard is visible or not and shows the "Done" button.