### PR TITLE
Fix unreachable Publish button and off-screen Map tutorial tooltip

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -75,6 +75,10 @@ export default function TabsLayout() {
           ),
         }}
       />
+      {/* Note editors live inside the tabs navigator so the center tab button stays
+          visible and can act as the Publish button; href: null keeps them out of the bar. */}
+      <Tabs.Screen name="add-note" options={{ href: null }} />
+      <Tabs.Screen name="edit-note" options={{ href: null }} />
     </Tabs>
   );
 }

--- a/app/(tabs)/add-note.tsx
+++ b/app/(tabs)/add-note.tsx
@@ -1,0 +1,2 @@
+import AddNoteScreen from "../../lib/screens/AddNoteScreen";
+export default AddNoteScreen;

--- a/app/(tabs)/edit-note.tsx
+++ b/app/(tabs)/edit-note.tsx
@@ -1,0 +1,2 @@
+import EditNoteScreen from "../../lib/screens/EditNoteScreen";
+export default EditNoteScreen;

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -43,8 +43,6 @@ function RootLayoutInner() {
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Protected guard={isOnboarded && isAuthenticated}>
           <Stack.Screen name="(tabs)" />
-          <Stack.Screen name="add-note" />
-          <Stack.Screen name="edit-note" />
           <Stack.Screen name="account" />
           <Stack.Screen name="video-player" />
         </Stack.Protected>

--- a/app/add-note.tsx
+++ b/app/add-note.tsx
@@ -1,2 +1,0 @@
-import AddNoteScreen from "../lib/screens/AddNoteScreen";
-export default AddNoteScreen;

--- a/app/edit-note.tsx
+++ b/app/edit-note.tsx
@@ -1,2 +1,0 @@
-import EditNoteScreen from "../lib/screens/EditNoteScreen";
-export default EditNoteScreen;

--- a/lib/screens/mapPage/ExploreScreen.tsx
+++ b/lib/screens/mapPage/ExploreScreen.tsx
@@ -304,81 +304,83 @@ const ExploreScreen = () => {
           <Ionicons name="search" size={25} onPress={handleSearch} color={colors.foreground} />
         </Tooltip>
       </View>
-      <Tooltip
-        isVisible={scrollTip}
-        showChildInTooltip={false}
-        topAdjustment={Platform.OS === "android" ? -250 : -250}
-        content={
-          <TooltipContent
-            message="Scroll left to view published notes all around the world!"
-            onPressOk={() => {
-              setScrollTip(false);
-              setTutorialDone("Explore", true);
-            }}
-            onSkip={() => {
-              setSearchToolTip(false);
-              setScrollTip(false);
-              setTutorialDone("Explore", true);
-            }}
-          />
-        }
-        placement="top"
-      >
-        <Animated.ScrollView
-          ref={_scrollView}
-          testID="cardScrollView"
-          horizontal
-          pagingEnabled
-          scrollEventThrottle={1}
-          showsHorizontalScrollIndicator={false}
-          snapToInterval={CARD_WIDTH + 20}
-          snapToAlignment="center"
-          style={{ position: "absolute", bottom: 90, left: 0, right: 0, paddingVertical: 10 }}
-          contentInset={{ top: 0, left: SPACING_FOR_CARD_INSET, bottom: 0, right: SPACING_FOR_CARD_INSET }}
-          contentContainerStyle={{ paddingHorizontal: Platform.OS === "android" ? SPACING_FOR_CARD_INSET : 0 }}
-          onScroll={Animated.event([{ nativeEvent: { contentOffset: { x: mapAnimation } } }], {
-            useNativeDriver: true,
-          })}
-        >
-          {markers.map((marker, index) => (
-            <MapNotesComponent key={index} index={index} marker={marker} onViewNote={onViewNote} />
-          ))}
-
-          {shouldShowLoadMore && (
-            <View
-              testID="loadMoreButton"
-              className="items-center justify-center"
-              style={{
-                width: CARD_WIDTH,
-                height: CARD_HEIGHT - 55,
-                marginRight: 30,
-                marginLeft: -30,
-                borderRadius: 3,
-                shadowColor: "#000",
-                shadowOffset: { width: 0, height: 2 },
-                shadowOpacity: 0.2,
-                shadowRadius: 3,
-                elevation: 0,
+      <View style={{ position: "absolute", bottom: 90, left: 0, right: 0 }}>
+        <Tooltip
+          isVisible={scrollTip}
+          showChildInTooltip={false}
+          topAdjustment={Platform.OS === "android" ? -(StatusBar.currentHeight ?? 0) : 0}
+          content={
+            <TooltipContent
+              message="Scroll left to view published notes all around the world!"
+              onPressOk={() => {
+                setScrollTip(false);
+                setTutorialDone("Explore", true);
               }}
-            >
-              {isFetchingNextPage ? (
-                <ActivityIndicator size="small" color={colors.foreground} />
-              ) : (
-                <TouchableOpacity
-                  testID="loadMoreTouchable"
-                  onPress={handleLoadMore}
-                  className="h-[50%] w-[70%] items-center justify-center rounded-[3px]"
-                  style={{ backgroundColor: accentColor }}
-                >
-                  <Text className="text-[32px]" style={{ color: colors.foreground }}>
-                    Load More
-                  </Text>
-                </TouchableOpacity>
-              )}
-            </View>
-          )}
-        </Animated.ScrollView>
-      </Tooltip>
+              onSkip={() => {
+                setSearchToolTip(false);
+                setScrollTip(false);
+                setTutorialDone("Explore", true);
+              }}
+            />
+          }
+          placement="top"
+        >
+          <Animated.ScrollView
+            ref={_scrollView}
+            testID="cardScrollView"
+            horizontal
+            pagingEnabled
+            scrollEventThrottle={1}
+            showsHorizontalScrollIndicator={false}
+            snapToInterval={CARD_WIDTH + 20}
+            snapToAlignment="center"
+            style={{ paddingVertical: 10 }}
+            contentInset={{ top: 0, left: SPACING_FOR_CARD_INSET, bottom: 0, right: SPACING_FOR_CARD_INSET }}
+            contentContainerStyle={{ paddingHorizontal: Platform.OS === "android" ? SPACING_FOR_CARD_INSET : 0 }}
+            onScroll={Animated.event([{ nativeEvent: { contentOffset: { x: mapAnimation } } }], {
+              useNativeDriver: true,
+            })}
+          >
+            {markers.map((marker, index) => (
+              <MapNotesComponent key={index} index={index} marker={marker} onViewNote={onViewNote} />
+            ))}
+
+            {shouldShowLoadMore && (
+              <View
+                testID="loadMoreButton"
+                className="items-center justify-center"
+                style={{
+                  width: CARD_WIDTH,
+                  height: CARD_HEIGHT - 55,
+                  marginRight: 30,
+                  marginLeft: -30,
+                  borderRadius: 3,
+                  shadowColor: "#000",
+                  shadowOffset: { width: 0, height: 2 },
+                  shadowOpacity: 0.2,
+                  shadowRadius: 3,
+                  elevation: 0,
+                }}
+              >
+                {isFetchingNextPage ? (
+                  <ActivityIndicator size="small" color={colors.foreground} />
+                ) : (
+                  <TouchableOpacity
+                    testID="loadMoreTouchable"
+                    onPress={handleLoadMore}
+                    className="h-[50%] w-[70%] items-center justify-center rounded-[3px]"
+                    style={{ backgroundColor: accentColor }}
+                  >
+                    <Text className="text-[32px]" style={{ color: colors.foreground }}>
+                      Load More
+                    </Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+            )}
+          </Animated.ScrollView>
+        </Tooltip>
+      </View>
 
       <NoteDetailModal isVisible={isModalVisible} onClose={() => setModalVisible(false)} note={selectedNote} />
     </View>


### PR DESCRIPTION
## Summary

Fixes two long-standing UX-breaking bugs. **Stacked on #279** (the SDK 56 upgrade) — merge that first, then re-target this to `main`.

### Bug 1: Publish button unreachable from the note editor
`AddNoteBtnComponent` (the center tab button) is designed to flip to **Publish** mode whenever the pathname is `/add-note` or `/edit-note` — but those routes lived in the **root stack**, so the editor covered the tab bar entirely and the Publish button could never be seen or tapped. Publishing a note from the editor was impossible on iOS.

**Fix:** move `add-note` and `edit-note` into the `(tabs)` navigator with `href: null` (hidden from the bar, tab bar stays visible). No screen code changes — the existing pathname logic and `AddNoteContext` wiring just start working.

### Bug 2: second Map tutorial tooltip renders off-screen
First-time users on the Map tab got a dimmed, unresponsive screen: the "Scroll left to view published notes" tooltip rendered ~250pt above the viewport, leaving an invisible modal blocking all input with no way to dismiss it.

Two causes:
- `topAdjustment={Platform.OS === "android" ? -250 : -250}` — a hardcoded 250pt shove on **both** platforms (the adjacent search tooltip does this correctly with `-(StatusBar.currentHeight ?? 0)` on Android only)
- The tooltip anchored to a zero-height wrapper in the top layout flow while the card scroller it describes is absolutely positioned at the bottom

**Fix:** platform-correct `topAdjustment`, and the absolute positioning moved to a wrapper around the Tooltip so it anchors to the real scroller area.

### Testing
- Verified on the iOS simulator with Maestro: created a note, tapped the (now visible) Publish tab button, got the "Note Published" toast, and confirmed `is_published = true` via the API/database
- Replayed the Map tutorial: both tooltip steps render on-screen and are dismissible
- `tsc --noEmit` clean, all 29 Jest tests pass