### PR TITLE
Extract shared NotesList and note editor pieces

### DIFF
--- a/lib/components/NoteEditor.tsx
+++ b/lib/components/NoteEditor.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { Dimensions, TextInput, TouchableOpacity, View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import Constants from "expo-constants";
+import { RichText, type EditorBridge } from "@10play/tentap-editor";
+import PhotoScroller from "./photoScroller";
+import AudioContainer from "./audio";
+import TagWindow from "./tagging";
+import { useTheme } from "./ThemeProvider";
+import type { AudioType, Media } from "../models/media_class";
+
+const { height } = Dimensions.get("window");
+
+interface NoteEditorHeaderProps {
+  title: string;
+  onChangeTitle: (title: string) => void;
+  onBack: () => void;
+  onTitleFocus?: () => void;
+  /** Background of the header row; differs between the add and edit screens. */
+  rowClassName?: string;
+}
+
+export function NoteEditorHeader({ title, onChangeTitle, onBack, onTitleFocus, rowClassName = "bg-accent" }: NoteEditorHeaderProps) {
+  return (
+    <View
+      className={`flex-row items-center justify-between px-[5px] text-center ${rowClassName}`}
+      style={{ paddingTop: Constants.statusBarHeight, height: height * 0.15 }}
+    >
+      <TouchableOpacity className="z-[99] h-[50px] w-[50px] items-center justify-center rounded-full bg-tertiary" onPress={onBack}>
+        <Ionicons name="arrow-back-outline" size={30} color="var(--color-foreground)" />
+      </TouchableOpacity>
+      <TextInput
+        className="mr-[5%] h-[45px] w-4/5 rounded-[18px] border border-foreground px-[10px] text-center text-[20px] text-foreground"
+        placeholder="Title Field Note"
+        placeholderTextColor="var(--color-foreground)"
+        onChangeText={onChangeTitle}
+        value={title}
+        onFocus={onTitleFocus}
+      />
+    </View>
+  );
+}
+
+interface NoteEditorActionRowProps {
+  onToggleMedia: () => void;
+  onToggleAudio: () => void;
+  onToggleLocation: () => void;
+  onToggleTags: () => void;
+  locationOff: boolean;
+}
+
+export function NoteEditorActionRow({
+  onToggleMedia,
+  onToggleAudio,
+  onToggleLocation,
+  onToggleTags,
+  locationOff,
+}: NoteEditorActionRowProps) {
+  return (
+    <View className="w-full flex-row items-center justify-between bg-primary px-10 py-[5px]">
+      <TouchableOpacity onPress={onToggleMedia} testID="imageButton">
+        <Ionicons name="images-outline" size={30} color="var(--color-foreground)" />
+      </TouchableOpacity>
+      <TouchableOpacity onPress={onToggleAudio}>
+        <Ionicons name="mic-outline" size={30} color="var(--color-foreground)" />
+      </TouchableOpacity>
+      <TouchableOpacity onPress={onToggleLocation} testID="checklocationpermission">
+        <Ionicons name="location-outline" size={30} color={locationOff ? "red" : "var(--color-foreground)"} />
+      </TouchableOpacity>
+      <TouchableOpacity onPress={onToggleTags}>
+        <Ionicons name="pricetag-outline" size={30} color="var(--color-foreground)" />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+interface NoteEditorPanelsProps {
+  viewMedia: boolean;
+  viewAudio: boolean;
+  isTagging: boolean;
+  media: Media[];
+  setMedia: React.Dispatch<React.SetStateAction<Media[]>>;
+  audio: AudioType[];
+  setAudio: React.Dispatch<React.SetStateAction<AudioType[]>>;
+  tags: string[];
+  setTags: React.Dispatch<React.SetStateAction<string[]>>;
+  insertImageToEditor: (imageUri: string) => Promise<void>;
+  addVideoToEditor: (videoUri: string) => Promise<void>;
+  insertAudioToEditor: (audioUri: string) => Promise<void>;
+}
+
+export function NoteEditorPanels({
+  viewMedia,
+  viewAudio,
+  isTagging,
+  media,
+  setMedia,
+  audio,
+  setAudio,
+  tags,
+  setTags,
+  insertImageToEditor,
+  addVideoToEditor,
+  insertAudioToEditor,
+}: NoteEditorPanelsProps) {
+  return (
+    <View className="mb-1 w-full bg-tertiary">
+      <PhotoScroller
+        active={viewMedia}
+        newMedia={media}
+        setNewMedia={setMedia}
+        insertImageToEditor={insertImageToEditor}
+        addVideoToEditor={addVideoToEditor}
+      />
+      {viewAudio && <AudioContainer newAudio={audio} setNewAudio={setAudio} insertAudioToEditor={insertAudioToEditor} />}
+      {isTagging && <TagWindow tags={tags} setTags={setTags} />}
+    </View>
+  );
+}
+
+interface NoteEditorBodyProps {
+  editor: EditorBridge;
+  testID?: string;
+}
+
+export function NoteEditorBody({ editor, testID }: NoteEditorBodyProps) {
+  const { colors } = useTheme();
+  return (
+    <View className="ios:h-full android:flex-1 min-h-[300px] grow pb-[120px]" testID={testID}>
+      <RichText
+        editor={editor}
+        style={{
+          flex: 1,
+          width: "100%",
+          minHeight: 200,
+          paddingBottom: 120,
+          padding: 10,
+          marginBottom: 4,
+          backgroundColor: colors.primary,
+        }}
+      />
+    </View>
+  );
+}

--- a/lib/components/NotesList.tsx
+++ b/lib/components/NotesList.tsx
@@ -1,0 +1,169 @@
+import React, { useState } from "react";
+import { ActivityIndicator, Platform, Text, TouchableOpacity, View } from "react-native";
+import { SwipeListView } from "react-native-swipe-list-view";
+import LottieView from "lottie-react-native";
+import { useRouter } from "expo-router";
+import { Note } from "../../types";
+import { formatToLocalDateString } from "./time";
+import { useTheme } from "./ThemeProvider";
+import NotesComponent from "./NotesComponent";
+import NoteDetailModal, { NoteDetailData } from "../screens/mapPage/NoteDetailModal";
+
+const TEXT_LENGTH = 18;
+
+export interface NoteSwipeActions {
+  renderHiddenItem: (data: { item: Note; index: number }, rowMap: any) => React.ReactElement;
+  leftActivationValue?: number;
+  rightActivationValue?: number;
+  leftOpenValue?: number;
+  rightOpenValue?: number;
+  stopLeftSwipe?: number;
+  stopRightSwipe?: number;
+  onLeftAction?: (rowKey: string, rowMap: any) => void;
+  onRightAction?: (rowKey: string, rowMap: any) => void;
+}
+
+interface NotesListProps {
+  notes: Note[];
+  hasMore: boolean;
+  isLoadingMore: boolean;
+  onLoadMore: () => void;
+  /** Called right before navigating to the edit screen for an unpublished note. */
+  onBeforeEditNote?: (note: Note) => void;
+  /** Class applied to each row's touchable wrapper (background color differs per screen). */
+  itemClassName?: string;
+  /** Swipe-to-publish/delete actions; omit for a plain list. */
+  swipeActions?: NoteSwipeActions;
+}
+
+const NotesList: React.FC<NotesListProps> = ({
+  notes,
+  hasMore,
+  isLoadingMore,
+  onLoadMore,
+  onBeforeEditNote,
+  itemClassName = "bg-secondary",
+  swipeActions,
+}) => {
+  const router = useRouter();
+  const { colors, isDarkmode } = useTheme();
+  const [selectedNote, setSelectedNote] = useState<NoteDetailData | undefined>(undefined);
+  const [isModalVisible, setModalVisible] = useState(false);
+
+  const handleNotePress = (item: Note) => {
+    if (!item.isPublished) {
+      onBeforeEditNote?.(item);
+      router.push({
+        pathname: "/edit-note",
+        params: { noteData: JSON.stringify({ ...item, time: item.time instanceof Date ? item.time.toISOString() : item.time }) },
+      });
+    } else {
+      setSelectedNote({
+        ...item,
+        time: formatToLocalDateString(new Date(item.time)),
+        description: item.text,
+        images: item.media.map((m: { uri: string }) => ({ uri: m.uri })),
+      });
+      setModalVisible(true);
+    }
+  };
+
+  const renderItem = (data: any) => {
+    const item = data.item;
+    const showTime = formatToLocalDateString(new Date(item.time));
+    const mediaItem = item.media[0];
+    const ImageType = mediaItem?.type;
+    let ImageURI = "";
+    let IsImage = false;
+    if (ImageType === "image") {
+      ImageURI = mediaItem.uri;
+      IsImage = true;
+    } else if (ImageType === "video") {
+      ImageURI = mediaItem.thumbnail;
+      IsImage = true;
+    }
+    const resolvedImageURI = Platform.OS === "android" ? String(ImageURI || "") : ImageURI;
+
+    return (
+      <TouchableOpacity
+        key={item.id}
+        testID={`note-item-${data.index}`}
+        activeOpacity={1}
+        className={itemClassName}
+        onPress={() => handleNotePress(item)}
+      >
+        <NotesComponent
+          IsImage={IsImage}
+          resolvedImageURI={resolvedImageURI}
+          ImageType={ImageType}
+          textLength={TEXT_LENGTH}
+          showTime={showTime}
+          item={item}
+          isPublished={item.isPublished}
+          isDarkmode={isDarkmode}
+        />
+      </TouchableOpacity>
+    );
+  };
+
+  const renderFooter = () => {
+    if (isLoadingMore) {
+      return (
+        <View className="mb-[100px] items-center py-[50px]">
+          <ActivityIndicator size="small" color={colors.foreground} />
+        </View>
+      );
+    }
+    if (hasMore) {
+      return (
+        <TouchableOpacity
+          testID="load-more"
+          onPress={onLoadMore}
+          className="my-1 w-[65%] items-center self-center rounded-lg bg-accent py-5"
+        >
+          <Text testID="load-more-button" className="font-inter text-base font-normal text-foreground">
+            Load More
+          </Text>
+        </TouchableOpacity>
+      );
+    }
+    return (
+      <View className="items-center p-5">
+        <Text testID="empty-state-text" className="font-inter text-sm text-gray-500">
+          End of the Page
+        </Text>
+      </View>
+    );
+  };
+
+  if (notes.length === 0) {
+    return (
+      <View className="items-center justify-center">
+        <LottieView
+          testID="no-results-animation"
+          source={require("../../assets/animations/noResultFound.json")}
+          autoPlay
+          loop
+          style={{ width: 100, height: 200 }}
+        />
+        <Text className="font-inter text-[15px] font-normal">No Results Found</Text>
+      </View>
+    );
+  }
+
+  return (
+    <>
+      <SwipeListView
+        data={notes}
+        renderItem={renderItem}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={{ paddingBottom: 150 }}
+        ListFooterComponent={renderFooter}
+        {...(swipeActions ?? {})}
+      />
+      <NoteDetailModal isVisible={isModalVisible} onClose={() => setModalVisible(false)} note={selectedNote} />
+    </>
+  );
+};
+
+export default NotesList;

--- a/lib/hooks/useNoteEditor.ts
+++ b/lib/hooks/useNoteEditor.ts
@@ -1,0 +1,108 @@
+import { useEffect, useState } from "react";
+import { Keyboard } from "react-native";
+import { useEditorBridge } from "@10play/tentap-editor";
+import { useTheme } from "../components/ThemeProvider";
+
+const customImageCSS = `
+  .ProseMirror img {
+    max-width: 200px !important;
+    max-height: 200px !important;
+    object-fit: cover !important;
+    display: inline-block;
+  }
+`;
+
+export function isBodyEmpty(htmlString: string): boolean {
+  return htmlString.replace(/<\/?[^>]+(>|$)/g, "").trim().length === 0;
+}
+
+export function useKeyboardVisible() {
+  const [keyboardVisible, setKeyboardVisible] = useState(false);
+
+  useEffect(() => {
+    const showListener = Keyboard.addListener("keyboardDidShow", () => setKeyboardVisible(true));
+    const hideListener = Keyboard.addListener("keyboardDidHide", () => setKeyboardVisible(false));
+    return () => {
+      showListener.remove();
+      hideListener.remove();
+    };
+  }, []);
+
+  return keyboardVisible;
+}
+
+/**
+ * Rich-text editor bridge for the note screens, with theme-aware CSS and
+ * helpers for appending media links/tags to the document.
+ */
+export function useNoteEditor(initialContent: string) {
+  const { colors } = useTheme();
+  const editor = useEditorBridge({
+    initialContent,
+    avoidIosKeyboard: true,
+  });
+
+  useEffect(() => {
+    if (editor) {
+      const combinedCSS = `
+        ${customImageCSS}
+        body {
+          color: ${colors.foreground};
+        }
+      `;
+      editor.injectCSS(combinedCSS);
+    }
+  }, [editor, colors.foreground]);
+
+  const displayErrorInEditor = async (errorMessage: string) => {
+    const currentContent = await editor.getHTML();
+    const errorTag = `<p style="color: red; font-weight: bold;">${errorMessage}</p><br />`;
+    editor.setContent(currentContent + errorTag);
+    editor.focus();
+  };
+
+  const insertImageToEditor = async (imageUri: string) => {
+    try {
+      const currentContent = await editor.getHTML();
+      const imageTag = `<img src="${imageUri}" style="max-width: 200px; max-height: 200px; object-fit: cover;" /><br />`;
+      editor.setContent(currentContent + imageTag);
+      editor.focus();
+    } catch (error) {
+      console.error("Error inserting image:", error);
+      displayErrorInEditor(`Error inserting image: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  };
+
+  const addVideoToEditor = async (videoUri: string) => {
+    try {
+      const currentContent = await editor.getHTML();
+      const videoLink = `${currentContent}<a href="${videoUri}">${videoUri}</a><br>`;
+      editor.setContent(videoLink);
+      editor.focus();
+    } catch (error) {
+      console.error("Error adding video:", error);
+      displayErrorInEditor(`Error adding video: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  };
+
+  const insertAudioToEditor = async (audioUri: string) => {
+    try {
+      const currentContent = await editor.getHTML();
+      const audioLink = `${currentContent}<a href="${audioUri}">${audioUri}</a><br>`;
+      editor.setContent(audioLink);
+      editor.focus();
+    } catch (error) {
+      console.error("Error adding audio:", error);
+      displayErrorInEditor(`Error adding audio: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  };
+
+  const handleDonePress = () => {
+    if (editor?.blur) {
+      editor.blur();
+    }
+    Keyboard.dismiss();
+  };
+
+  return { editor, insertImageToEditor, addVideoToEditor, insertAudioToEditor, handleDonePress };
+}

--- a/lib/hooks/useNoteLocation.ts
+++ b/lib/hooks/useNoteLocation.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState } from "react";
+import { Alert } from "react-native";
+import * as Location from "expo-location";
+
+export interface NoteCoordinates {
+  latitude: number;
+  longitude: number;
+}
+
+/**
+ * Device location for the note editor screens. Fetches the current position
+ * silently on mount; (0,0) means location tagging is turned off.
+ */
+export function useNoteLocation(initial?: NoteCoordinates | null) {
+  const [location, setLocation] = useState<NoteCoordinates | null>(initial ?? null);
+
+  const setLocationToZero = useCallback(() => {
+    setLocation({ latitude: 0, longitude: 0 });
+  }, []);
+
+  // silent: skip the error alert for automatic fetches (e.g. on mount), where it
+  // can fire after the user has already navigated away.
+  const fetchCurrentLocation = useCallback(
+    async ({ silent = false } = {}) => {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+
+      if (status === "granted") {
+        try {
+          const userLocation = await Location.getCurrentPositionAsync({});
+          setLocation({
+            latitude: userLocation.coords.latitude,
+            longitude: userLocation.coords.longitude,
+          });
+        } catch (error) {
+          console.error("Error fetching location:", error);
+          if (!silent) {
+            Alert.alert("Error", "Failed to retrieve location.");
+          }
+          setLocationToZero();
+        }
+      } else {
+        setLocationToZero();
+      }
+    },
+    [setLocationToZero]
+  );
+
+  useEffect(() => {
+    fetchCurrentLocation({ silent: true });
+  }, [fetchCurrentLocation]);
+
+  const isLocationOff = location !== null && location.latitude === 0 && location.longitude === 0;
+
+  const toggleLocation = useCallback(() => {
+    if (isLocationOff) {
+      fetchCurrentLocation();
+    } else {
+      setLocationToZero();
+    }
+  }, [isLocationOff, fetchCurrentLocation, setLocationToZero]);
+
+  return { location, isLocationOff, toggleLocation };
+}

--- a/lib/screens/AddNoteScreen.tsx
+++ b/lib/screens/AddNoteScreen.tsx
@@ -1,50 +1,22 @@
-import { Ionicons } from "@expo/vector-icons";
-
-import React, { useCallback, useEffect, useEffectEvent, useRef, useState } from "react";
-import {
-  Alert,
-  View,
-  TextInput,
-  TouchableOpacity,
-  Keyboard,
-  Platform,
-  KeyboardAvoidingView,
-  Modal,
-  Text,
-  StatusBar,
-  Dimensions,
-} from "react-native";
-import * as Location from "expo-location";
+import React, { useEffect, useEffectEvent, useRef, useState } from "react";
+import { View, TouchableOpacity, Platform, KeyboardAvoidingView, Modal, Text, StatusBar } from "react-native";
 import ToastMessage from "react-native-toast-message";
-import AudioContainer from "../components/audio";
-import Constants from "expo-constants";
 
-import PhotoScroller from "../components/photoScroller";
-import TagWindow from "../components/tagging";
-import { DEFAULT_TOOLBAR_ITEMS, RichText, Toolbar, useEditorBridge } from "@10play/tentap-editor";
-import { useTheme } from "../components/ThemeProvider";
+import { DEFAULT_TOOLBAR_ITEMS, Toolbar } from "@10play/tentap-editor";
 import LoadingModal from "../components/LoadingModal";
+import { NoteEditorHeader, NoteEditorActionRow, NoteEditorPanels, NoteEditorBody } from "../components/NoteEditor";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { VideoView, useVideoPlayer } from "expo-video";
 import { getHasDoneTutorial, setTutorialDone } from "../utils/tutorial";
 import type { AudioType, Media } from "../models/media_class";
 import { useCreateNote } from "../hooks/mutations/useCreateNote";
+import { useNoteLocation } from "../hooks/useNoteLocation";
+import { useNoteEditor, useKeyboardVisible, isBodyEmpty } from "../hooks/useNoteEditor";
 import { useAddNoteStore } from "../stores/addNoteStore";
 import { useAddNoteContext } from "../context/AddNoteContext";
 import TooltipContent from "../onboarding/TooltipComponent";
 import Tooltip from "react-native-walkthrough-tooltip";
 import { useRouter, useLocalSearchParams, useNavigation } from "expo-router";
-
-const customImageCSS = `
-  .ProseMirror img {
-    max-width: 200px !important;
-    max-height: 200px !important;
-    object-fit: cover !important;
-    display: inline-block;
-  }
-`;
-
-const { height } = Dimensions.get("window");
 
 const AddNoteScreen: React.FC = () => {
   const router = useRouter();
@@ -59,15 +31,11 @@ const AddNoteScreen: React.FC = () => {
   const [viewAudio, setViewAudio] = useState<boolean>(false);
   const [isTagging, setIsTagging] = useState<boolean>(false);
   const [isPublished, setIsPublished] = useState<boolean>(false);
-  const [location, setLocation] = useState<{
-    latitude: number;
-    longitude: number;
-  } | null>(null);
-  const [locationButtonColor, setLocationButtonColor] = useState<string>("#000");
   const [isVideoModalVisible, setIsVideoModalVisible] = useState<boolean>(false);
   const [videoUri] = useState<string | null>(null);
-  const [keyboardVisible, setKeyboardVisible] = useState(false);
   const videoPlayer = useVideoPlayer(videoUri);
+  const { location, isLocationOff, toggleLocation } = useNoteLocation();
+  const keyboardVisible = useKeyboardVisible();
   const { setPublishNote } = useAddNoteContext();
   const bodyTextRef = useRef(bodyText);
   const tagsRef = useRef(tags);
@@ -79,10 +47,7 @@ const AddNoteScreen: React.FC = () => {
   const createNoteMutation = useCreateNote();
   const { toggleAddNoteState } = useAddNoteStore();
 
-  const editor = useEditorBridge({
-    initialContent: bodyText || "",
-    avoidIosKeyboard: true,
-  });
+  const { editor, insertImageToEditor, addVideoToEditor, insertAudioToEditor, handleDonePress } = useNoteEditor(bodyText || "");
 
   useEffect(() => {
     titleTxtRef.current = titleText;
@@ -138,7 +103,6 @@ const AddNoteScreen: React.FC = () => {
     return unsubscribe;
   }, [navigation]);
 
-  const { colors } = useTheme();
   const scrollViewRef = useRef<KeyboardAwareScrollView>(null);
 
   const onPublish = useEffectEvent(() => handleShareButtonPress());
@@ -146,128 +110,6 @@ const AddNoteScreen: React.FC = () => {
   useEffect(() => {
     setPublishNote(() => onPublish);
   }, [setPublishNote]);
-
-  useEffect(() => {
-    if (editor) {
-      const combinedCSS = `
-        ${customImageCSS}
-        body {
-          color: ${colors.foreground};
-        }
-      `;
-      editor.injectCSS(combinedCSS);
-    }
-  }, [editor, colors.foreground]);
-
-  const isBodyEmpty = (htmlString: string) => {
-    const textOnly = htmlString.replace(/<\/?[^>]+(>|$)/g, "").trim();
-    return textOnly.length === 0;
-  };
-
-  useEffect(() => {
-    const showKeyboardListener = Keyboard.addListener("keyboardDidShow", () => {
-      setKeyboardVisible(true);
-    });
-    const hideKeyboardListener = Keyboard.addListener("keyboardDidHide", () => {
-      setKeyboardVisible(false);
-    });
-
-    return () => {
-      showKeyboardListener.remove();
-      hideKeyboardListener.remove();
-    };
-  }, []);
-
-  useEffect(() => {
-    if (editor) {
-      editor.injectCSS(customImageCSS);
-    }
-  }, [editor]);
-
-  const setLocationToZero = () => {
-    setLocation({ latitude: 0, longitude: 0 });
-    setLocationButtonColor("red");
-  };
-
-  // silent: skip the error alert for automatic fetches (e.g. on mount), where it
-  // can fire after the user has already navigated away.
-  const fetchCurrentLocation = useCallback(async ({ silent = false } = {}) => {
-    const { status } = await Location.requestForegroundPermissionsAsync();
-
-    if (status === "granted") {
-      try {
-        const userLocation = await Location.getCurrentPositionAsync({});
-        setLocation({
-          latitude: userLocation.coords.latitude,
-          longitude: userLocation.coords.longitude,
-        });
-        setLocationButtonColor("#000");
-      } catch (error) {
-        console.error("Error fetching location:", error);
-        if (!silent) {
-          Alert.alert("Error", "Failed to retrieve location.");
-        }
-        setLocationToZero();
-      }
-    } else {
-      setLocationToZero();
-    }
-  }, []);
-
-  const toggleLocation = () => {
-    if (location && location.latitude === 0 && location.longitude === 0) {
-      fetchCurrentLocation();
-    } else {
-      setLocationToZero();
-    }
-  };
-
-  useEffect(() => {
-    fetchCurrentLocation({ silent: true });
-  }, [fetchCurrentLocation]);
-
-  const displayErrorInEditor = async (errorMessage: string) => {
-    const currentContent = await editor.getHTML();
-    const errorTag = `<p style="color: red; font-weight: bold;">${errorMessage}</p><br />`;
-    editor.setContent(currentContent + errorTag);
-    editor.focus();
-  };
-
-  const insertImageToEditor = async (imageUri: string) => {
-    try {
-      const currentContent = await editor.getHTML();
-      const imageTag = `<img src="${imageUri}" style="max-width: 200px; max-height: 200px; object-fit: cover;" /><br />`;
-      editor.setContent(currentContent + imageTag);
-      editor.focus();
-    } catch (error) {
-      console.error("Error inserting image:", error);
-      displayErrorInEditor(`Error inserting image: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  };
-
-  const addVideoToEditor = async (videoUri: string) => {
-    try {
-      const currentContent = await editor.getHTML();
-      const videoLink = `${currentContent}<a href="${videoUri}">${videoUri}</a><br>`;
-      editor.setContent(videoLink);
-      editor.focus();
-    } catch (error) {
-      console.error("Error adding video:", error);
-      displayErrorInEditor(`Error adding video: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  };
-
-  const insertAudioToEditor = async (audioUri: string) => {
-    try {
-      const currentContent = await editor.getHTML();
-      const audioLink = `${currentContent}<a href="${audioUri}">${audioUri}</a><br>`;
-      editor.setContent(audioLink);
-      editor.focus();
-    } catch (error) {
-      console.error("Error adding audio:", error);
-      displayErrorInEditor(`Error adding audio: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  };
 
   const handleShareButtonPress = async () => {
     await syncEditorContent();
@@ -328,11 +170,6 @@ const AddNoteScreen: React.FC = () => {
     }
   };
 
-  const handleDonePress = () => {
-    editor.blur();
-    Keyboard.dismiss();
-  };
-
   const syncEditorContent = async () => {
     const latestContent = await editor.getHTML();
     setBodyText(latestContent);
@@ -382,71 +219,41 @@ const AddNoteScreen: React.FC = () => {
               placement="bottom"
             >
               <View className="min-h-[140px]">
-                <View
-                  className="flex-row items-center justify-between bg-accent px-[5px] text-center"
-                  style={{ paddingTop: Constants.statusBarHeight, height: height * 0.15 }}
-                >
-                  <TouchableOpacity
-                    className="z-[99] h-[50px] w-[50px] items-center justify-center rounded-full bg-tertiary"
-                    onPress={() => saveNote(false)}
-                  >
-                    <Ionicons name="arrow-back-outline" size={30} color="var(--color-foreground)" />
-                  </TouchableOpacity>
-                  <TextInput
-                    className="mr-[5%] h-[45px] w-4/5 rounded-[18px] border border-foreground px-[10px] text-center text-[20px] text-foreground"
-                    placeholder="Title Field Note"
-                    placeholderTextColor="var(--color-foreground)"
-                    onChangeText={setTitleText}
-                    value={titleText}
-                    onFocus={() => {
-                      if (editor?.blur) {
-                        editor.blur();
-                      }
-                    }}
-                  />
-                </View>
-                <View className="w-full flex-row items-center justify-between bg-primary px-10 py-[5px]">
-                  <TouchableOpacity onPress={() => setViewMedia(!viewMedia)} testID="imageButton">
-                    <Ionicons name="images-outline" size={30} color="var(--color-foreground)" />
-                  </TouchableOpacity>
-                  <TouchableOpacity onPress={() => setViewAudio(!viewAudio)}>
-                    <Ionicons name="mic-outline" size={30} color="var(--color-foreground)" />
-                  </TouchableOpacity>
-                  <TouchableOpacity onPress={toggleLocation} testID="checklocationpermission">
-                    <Ionicons name="location-outline" size={30} color={locationButtonColor} />
-                  </TouchableOpacity>
-                  <TouchableOpacity onPress={() => setIsTagging(!isTagging)}>
-                    <Ionicons name="pricetag-outline" size={30} color="var(--color-foreground)" />
-                  </TouchableOpacity>
-                </View>
+                <NoteEditorHeader
+                  title={titleText}
+                  onChangeTitle={setTitleText}
+                  onBack={() => saveNote(false)}
+                  onTitleFocus={() => {
+                    if (editor?.blur) {
+                      editor.blur();
+                    }
+                  }}
+                />
+                <NoteEditorActionRow
+                  onToggleMedia={() => setViewMedia(!viewMedia)}
+                  onToggleAudio={() => setViewAudio(!viewAudio)}
+                  onToggleLocation={toggleLocation}
+                  onToggleTags={() => setIsTagging(!isTagging)}
+                  locationOff={isLocationOff}
+                />
               </View>
             </Tooltip>
 
-            <View className="mb-1 w-full bg-tertiary">
-              <PhotoScroller
-                active={viewMedia}
-                newMedia={newMedia}
-                setNewMedia={setNewMedia}
-                insertImageToEditor={insertImageToEditor}
-                addVideoToEditor={addVideoToEditor}
-              />
-              {viewAudio && <AudioContainer newAudio={newAudio} setNewAudio={setNewAudio} insertAudioToEditor={insertAudioToEditor} />}
-              {isTagging && <TagWindow tags={tags} setTags={setTags} />}
-            </View>
-            <View className="ios:h-full android:flex-1 min-h-[300px] grow pb-[120px]" testID="TenTapEditor">
-              <RichText
-                editor={editor}
-                style={{
-                  flex: 1,
-                  width: "100%",
-                  minHeight: 200,
-                  paddingBottom: 120,
-                  padding: 10,
-                  marginBottom: 4,
-                  backgroundColor: colors.primary,
-                }}
-              />
-            </View>
+            <NoteEditorPanels
+              viewMedia={viewMedia}
+              viewAudio={viewAudio}
+              isTagging={isTagging}
+              media={newMedia}
+              setMedia={setNewMedia}
+              audio={newAudio}
+              setAudio={setNewAudio}
+              tags={tags}
+              setTags={setTags}
+              insertImageToEditor={insertImageToEditor}
+              addVideoToEditor={addVideoToEditor}
+              insertAudioToEditor={insertAudioToEditor}
+            />
+            <NoteEditorBody editor={editor} testID="TenTapEditor" />
 
             <View className="ios:h-[50px] android:h-[70px] absolute bottom-[27px] z-10 w-full justify-center px-[10px]" testID="RichEditor">
               <Toolbar editor={editor} items={DEFAULT_TOOLBAR_ITEMS} />

--- a/lib/screens/EditNoteScreen.tsx
+++ b/lib/screens/EditNoteScreen.tsx
@@ -1,33 +1,18 @@
-import React, { useState, useCallback, useEffect, useEffectEvent, useRef, useMemo } from "react";
-import { View, TextInput, TouchableOpacity, KeyboardAvoidingView, Platform, Keyboard, Alert, Text, Dimensions } from "react-native";
+import React, { useState, useEffect, useEffectEvent, useRef, useMemo } from "react";
+import { View, TouchableOpacity, KeyboardAvoidingView, Platform, Text } from "react-native";
 import ToastMessage from "react-native-toast-message";
-import { Ionicons } from "@expo/vector-icons";
-import * as Location from "expo-location";
-import Constants from "expo-constants";
-import PhotoScroller from "../components/photoScroller";
 import { useAuthStore } from "../stores/authStore";
-import AudioContainer from "../components/audio";
 import type { Media, AudioType } from "../models/media_class";
 import { useUpdateNote } from "../hooks/mutations/useUpdateNote";
-import TagWindow from "../components/tagging";
-import { DEFAULT_TOOLBAR_ITEMS, RichText, Toolbar, useEditorBridge } from "@10play/tentap-editor";
-import { useTheme } from "../components/ThemeProvider";
+import { useNoteLocation } from "../hooks/useNoteLocation";
+import { useNoteEditor, useKeyboardVisible } from "../hooks/useNoteEditor";
+import { DEFAULT_TOOLBAR_ITEMS, Toolbar } from "@10play/tentap-editor";
 import LoadingModal from "../components/LoadingModal";
+import { NoteEditorHeader, NoteEditorActionRow, NoteEditorPanels, NoteEditorBody } from "../components/NoteEditor";
 import { useAddNoteContext } from "../context/AddNoteContext";
 import { useAddNoteStore } from "../stores/addNoteStore";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { useRouter, useLocalSearchParams, useNavigation } from "expo-router";
-
-const customImageCSS = `
-  .ProseMirror img {
-    max-width: 200px !important;
-    max-height: 200px !important;
-    object-fit: cover !important;
-    display: inline-block;
-  }
-`;
-
-const { height } = Dimensions.get("window");
 
 const EditNoteScreen = () => {
   const router = useRouter();
@@ -41,48 +26,26 @@ const EditNoteScreen = () => {
       return {};
     }
   }, [noteData]);
-  const [keyboardVisible, setKeyboardVisible] = useState(false);
+  const keyboardVisible = useKeyboardVisible();
 
   const [title, setTitle] = useState(note.title || "Untitled");
   const [time] = useState(new Date(note.time));
-  const [tags, setTags] = useState(note.tags || []);
+  const [tags, setTags] = useState<string[]>(note.tags || []);
   const [media, setMedia] = useState<Media[]>(note.media || []);
   const [newAudio, setNewAudio] = useState<AudioType[]>(note.audio || []);
   const [isPublished, setIsPublished] = useState(note.isPublished || false);
   const [ispublishBtnClicked, setIsPublishBtnClicked] = useState(false);
-  const [location, setLocation] = useState({
+  const { location, isLocationOff, toggleLocation } = useNoteLocation({
     latitude: note.latitude || 0,
     longitude: note.longitude || 0,
   });
   const [isTagging, setIsTagging] = useState(false);
   const [viewMedia, setViewMedia] = useState(false);
   const [viewAudio, setViewAudio] = useState(false);
-  const { colors } = useTheme();
   const updateNoteMutation = useUpdateNote();
   const toggleAddNoteState = useAddNoteStore((s) => s.toggleAddNoteState);
-  const editor = useEditorBridge({
-    initialContent: note.text || "",
-    avoidIosKeyboard: true,
-  });
+  const { editor, insertImageToEditor, addVideoToEditor, insertAudioToEditor, handleDonePress } = useNoteEditor(note.text || "");
   const { setPublishNote } = useAddNoteContext();
-
-  useEffect(() => {
-    const showSub = Keyboard.addListener("keyboardDidShow", () => {
-      setKeyboardVisible(true);
-    });
-    const hideSub = Keyboard.addListener("keyboardDidHide", () => {
-      setKeyboardVisible(false);
-    });
-    return () => {
-      showSub.remove();
-      hideSub.remove();
-    };
-  }, []);
-
-  const handleDonePress = () => {
-    if (editor?.blur) editor.blur();
-    Keyboard.dismiss();
-  };
 
   const initialText = useRef(note.text || "");
 
@@ -93,98 +56,6 @@ const EditNoteScreen = () => {
   }, [setPublishNote]);
 
   const scrollViewRef = useRef(null);
-
-  useEffect(() => {
-    if (editor) {
-      const combinedCSS = `
-        ${customImageCSS}
-        body {
-          color: ${colors.foreground};
-        }
-      `;
-      editor.injectCSS(combinedCSS);
-    }
-  }, [editor, colors.foreground]);
-
-  const setLocationToZero = () => {
-    setLocation({ latitude: 0, longitude: 0 });
-  };
-
-  // silent: skip the error alert for automatic fetches (e.g. on mount), where it
-  // can fire after the user has already navigated away.
-  const fetchCurrentLocation = useCallback(async ({ silent = false } = {}) => {
-    const { status } = await Location.requestForegroundPermissionsAsync();
-    if (status === "granted") {
-      try {
-        const userLocation = await Location.getCurrentPositionAsync({});
-        setLocation({
-          latitude: userLocation.coords.latitude,
-          longitude: userLocation.coords.longitude,
-        });
-      } catch {
-        if (!silent) {
-          Alert.alert("Error", "Failed to retrieve location.");
-        }
-        setLocationToZero();
-      }
-    } else {
-      setLocationToZero();
-    }
-  }, []);
-
-  const toggleLocation = () => {
-    if (location.latitude === 0 && location.longitude === 0) {
-      fetchCurrentLocation();
-    } else {
-      setLocationToZero();
-    }
-  };
-
-  useEffect(() => {
-    fetchCurrentLocation({ silent: true });
-  }, [fetchCurrentLocation]);
-
-  const insertImageToEditor = async (imageUri: string) => {
-    try {
-      const currentContent = await editor.getHTML();
-      const imageTag = `<img src="${imageUri}" style="max-width: 200px; max-height: 200px; object-fit: cover;" /><br />`;
-      editor.setContent(currentContent + imageTag);
-      editor.focus();
-    } catch (error) {
-      console.error("Error inserting image:", error);
-      displayErrorInEditor(`Error inserting image: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  };
-
-  const addVideoToEditor = async (videoUri: string) => {
-    try {
-      const currentContent = await editor.getHTML();
-      const videoLink = `${currentContent}<a href="${videoUri}">${videoUri}</a><br>`;
-      editor.setContent(videoLink);
-      editor.focus();
-    } catch (error) {
-      console.error("Error adding video:", error);
-      displayErrorInEditor(`Error adding video: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  };
-
-  const displayErrorInEditor = async (errorMessage: string) => {
-    const currentContent = await editor.getHTML();
-    const errorTag = `<p style="color: red; font-weight: bold;">${errorMessage}</p><br />`;
-    editor.setContent(currentContent + errorTag);
-    editor.focus();
-  };
-
-  const insertAudioToEditor = async (audioUri: string) => {
-    try {
-      const currentContent = await editor.getHTML();
-      const audioLink = `${currentContent}<a href="${audioUri}">${audioUri}</a><br>`;
-      editor.setContent(audioLink);
-      editor.focus();
-    } catch (error) {
-      console.error("Error adding audio:", error);
-    }
-  };
 
   const handlePublishPress = async () => {
     const latestContent = await editor.getHTML();
@@ -203,8 +74,8 @@ const EditNoteScreen = () => {
           text: latestContent,
           creatorId: authUser?.id,
           media,
-          latitude: location.latitude,
-          longitude: location.longitude,
+          latitude: location?.latitude ?? 0,
+          longitude: location?.longitude ?? 0,
           audio: newAudio,
           isPublished: true,
           time,
@@ -238,8 +109,8 @@ const EditNoteScreen = () => {
         text: textContent,
         creatorId: authUser?.id,
         media,
-        latitude: location.latitude,
-        longitude: location.longitude,
+        latitude: location?.latitude ?? 0,
+        longitude: location?.longitude ?? 0,
         audio: newAudio,
         isPublished,
         time,
@@ -268,8 +139,8 @@ const EditNoteScreen = () => {
           audio: newAudio,
           tags,
           isPublished,
-          latitude: location.latitude,
-          longitude: location.longitude,
+          latitude: location?.latitude ?? 0,
+          longitude: location?.longitude ?? 0,
           time: new Date(),
         };
 
@@ -299,69 +170,32 @@ const EditNoteScreen = () => {
       >
         <KeyboardAwareScrollView ref={scrollViewRef} contentContainerStyle={{ flexGrow: 1 }} keyboardShouldPersistTaps="handled">
           <View className="min-h-[140px] bg-accent">
-            <View
-              className="flex-row items-center justify-between bg-primary px-[5px] text-center"
-              style={{ paddingTop: Constants.statusBarHeight, height: height * 0.15 }}
-            >
-              <TouchableOpacity
-                className="z-[99] h-[50px] w-[50px] items-center justify-center rounded-full bg-tertiary"
-                onPress={handleSaveNote}
-              >
-                <Ionicons name="arrow-back-outline" size={30} color="var(--color-foreground)" />
-              </TouchableOpacity>
-              <TextInput
-                className="mr-[5%] h-[45px] w-4/5 rounded-[18px] border border-foreground px-[10px] text-center text-[20px] text-foreground"
-                placeholder="Title Field Note"
-                value={title}
-                onChangeText={setTitle}
-              />
-            </View>
-            <View className="w-full flex-row items-center justify-between bg-primary px-10 py-[5px]">
-              <TouchableOpacity onPress={() => setViewMedia(!viewMedia)}>
-                <Ionicons name="images-outline" size={30} color="var(--color-foreground)" />
-              </TouchableOpacity>
-              <TouchableOpacity onPress={() => setViewAudio(!viewAudio)}>
-                <Ionicons name="mic-outline" size={30} color="var(--color-foreground)" />
-              </TouchableOpacity>
-              <TouchableOpacity onPress={toggleLocation}>
-                <Ionicons
-                  name="location-outline"
-                  size={30}
-                  color={location.latitude === 0 && location.longitude === 0 ? "red" : "var(--color-foreground)"}
-                />
-              </TouchableOpacity>
-              <TouchableOpacity onPress={() => setIsTagging(!isTagging)}>
-                <Ionicons name="pricetag-outline" size={30} color="var(--color-foreground)" />
-              </TouchableOpacity>
-            </View>
-          </View>
-
-          <View className="mb-1 w-full bg-tertiary">
-            <PhotoScroller
-              active={viewMedia}
-              newMedia={media}
-              setNewMedia={setMedia}
-              insertImageToEditor={insertImageToEditor}
-              addVideoToEditor={addVideoToEditor}
-            />
-            {viewAudio && <AudioContainer newAudio={newAudio} setNewAudio={setNewAudio} insertAudioToEditor={insertAudioToEditor} />}
-            {isTagging && <TagWindow tags={tags} setTags={setTags} />}
-          </View>
-
-          <View className="ios:h-full android:flex-1 min-h-[300px] grow pb-[120px]">
-            <RichText
-              editor={editor}
-              style={{
-                flex: 1,
-                width: "100%",
-                minHeight: 200,
-                paddingBottom: 120,
-                padding: 10,
-                marginBottom: 4,
-                backgroundColor: colors.primary,
-              }}
+            <NoteEditorHeader title={title} onChangeTitle={setTitle} onBack={handleSaveNote} rowClassName="bg-primary" />
+            <NoteEditorActionRow
+              onToggleMedia={() => setViewMedia(!viewMedia)}
+              onToggleAudio={() => setViewAudio(!viewAudio)}
+              onToggleLocation={toggleLocation}
+              onToggleTags={() => setIsTagging(!isTagging)}
+              locationOff={isLocationOff}
             />
           </View>
+
+          <NoteEditorPanels
+            viewMedia={viewMedia}
+            viewAudio={viewAudio}
+            isTagging={isTagging}
+            media={media}
+            setMedia={setMedia}
+            audio={newAudio}
+            setAudio={setNewAudio}
+            tags={tags}
+            setTags={setTags}
+            insertImageToEditor={insertImageToEditor}
+            addVideoToEditor={addVideoToEditor}
+            insertAudioToEditor={insertAudioToEditor}
+          />
+
+          <NoteEditorBody editor={editor} />
 
           {Platform.OS === "ios" && (
             <View className="absolute bottom-[27px] z-10 h-[50px] w-full justify-center px-[10px]" testID="Toolbar">

--- a/lib/screens/HomeScreen.tsx
+++ b/lib/screens/HomeScreen.tsx
@@ -1,28 +1,13 @@
 import React, { useState, useEffect } from "react";
-import {
-  Platform,
-  View,
-  Text,
-  TouchableOpacity,
-  Dimensions,
-  TextInput,
-  Pressable,
-  Animated,
-  StatusBar,
-  ActivityIndicator,
-} from "react-native";
+import { Platform, View, Text, TouchableOpacity, Dimensions, TextInput, Pressable, Animated, StatusBar } from "react-native";
 import { Ionicons, MaterialIcons } from "@expo/vector-icons";
 import { Note } from "../../types";
-import { SwipeListView } from "react-native-swipe-list-view";
 import NoteSkeleton from "../components/noteSkeleton";
-import { formatToLocalDateString } from "../components/time";
 import { useTheme } from "../components/ThemeProvider";
-import NoteDetailModal, { NoteDetailData } from "./mapPage/NoteDetailModal";
 import ToastMessage from "react-native-toast-message";
-import NotesComponent from "../components/NotesComponent";
+import NotesList from "../components/NotesList";
 import Greeting from "../components/Greeting";
 import { useAddNoteContext } from "../context/AddNoteContext";
-import LottieView from "lottie-react-native";
 import { useAddNoteStore } from "../stores/addNoteStore";
 import Tooltip from "react-native-walkthrough-tooltip";
 import TooltipContent from "../onboarding/TooltipComponent";
@@ -33,7 +18,6 @@ import { useUpdateNote } from "../hooks/mutations/useUpdateNote";
 import Constants from "expo-constants";
 
 const { width } = Dimensions.get("window");
-const TEXT_LENGTH = 18;
 
 const HomeScreen: React.FC = () => {
   const router = useRouter();
@@ -44,8 +28,6 @@ const HomeScreen: React.FC = () => {
 
   const [isPrivate, setIsPrivate] = useState(true);
   const [published, setPublished] = useState(false);
-  const [selectedNote, setSelectedNote] = useState<NoteDetailData | undefined>(undefined);
-  const [isModalVisible, setModalVisible] = useState(false);
   const [isSortOpened, setIsSortOpened] = useState(false);
   const [selectedSortOption, setSelectedSortOption] = useState(1);
 
@@ -117,60 +99,6 @@ const HomeScreen: React.FC = () => {
   const publicData = displayNotes.filter((n) => n.isPublished);
   const listData = isPrivate ? privateData : publicData;
 
-  const renderItem = (data: any) => {
-    const item = data.item;
-    const showTime = formatToLocalDateString(new Date(item.time));
-    const mediaItem = item.media[0];
-    const ImageType = mediaItem?.type;
-    let ImageURI = "";
-    let IsImage = false;
-    if (ImageType === "image") {
-      ImageURI = mediaItem.uri;
-      IsImage = true;
-    } else if (ImageType === "video") {
-      ImageURI = mediaItem.thumbnail;
-      IsImage = true;
-    }
-    const resolvedImageURI = Platform.OS === "android" ? String(ImageURI || "") : ImageURI;
-
-    return (
-      <TouchableOpacity
-        key={item.id}
-        testID={`note-item-${data.index}`}
-        activeOpacity={1}
-        className="w-full bg-[#e6e6e6] dark:bg-black"
-        onPress={() => {
-          if (!item.isPublished) {
-            toggleAddNoteState();
-            router.push({
-              pathname: "/edit-note",
-              params: { noteData: JSON.stringify({ ...item, time: item.time.toISOString() }) },
-            });
-          } else {
-            setSelectedNote({
-              ...item,
-              time: formatToLocalDateString(new Date(item.time)),
-              description: item.text,
-              images: item.media.map((m: { uri: string }) => ({ uri: m.uri })),
-            });
-            setModalVisible(true);
-          }
-        }}
-      >
-        <NotesComponent
-          IsImage={IsImage}
-          resolvedImageURI={resolvedImageURI}
-          ImageType={ImageType}
-          textLength={TEXT_LENGTH}
-          showTime={showTime}
-          item={item}
-          isPublished={item.isPublished}
-          isDarkmode={isDarkmode}
-        />
-      </TouchableOpacity>
-    );
-  };
-
   const sideMenu = (data: any, rowMap: any) => {
     const isNotePublished = data.item.isPublished;
     return (
@@ -193,70 +121,27 @@ const HomeScreen: React.FC = () => {
     );
   };
 
-  const renderFooter = () => {
-    if (isLoadingMore) {
-      return (
-        <View className="mb-[100px] items-center py-[50px]">
-          <ActivityIndicator size="small" className="text-foreground" />
-        </View>
-      );
-    }
-    if (hasMore) {
-      return (
-        <TouchableOpacity
-          testID="load-more"
-          onPress={handleLoadMore}
-          className="my-1 w-[65%] items-center self-center rounded-lg bg-accent py-5"
-        >
-          <Text testID="load-more-button" className="font-inter text-base font-normal text-foreground">
-            Load More
-          </Text>
-        </TouchableOpacity>
-      );
-    }
-    return (
-      <View className="items-center p-5">
-        <Text testID="empty-state-text" className="font-inter text-sm text-gray-500">
-          End of the Page
-        </Text>
-      </View>
-    );
-  };
-
-  const renderList = () => {
-    if (listData.length === 0) {
-      return (
-        <View className="items-center justify-center">
-          <LottieView
-            testID="no-results-animation"
-            source={require("../../assets/animations/noResultFound.json")}
-            autoPlay
-            loop
-            style={{ width: 100, height: 200 }}
-          />
-          <Text className="font-inter text-[15px] font-normal">No Results Found</Text>
-        </View>
-      );
-    }
-    return (
-      <SwipeListView
-        data={listData}
-        renderItem={renderItem}
-        renderHiddenItem={sideMenu}
-        leftActivationValue={160}
-        rightActivationValue={isPrivate ? -160 : undefined}
-        leftOpenValue={75}
-        rightOpenValue={isPrivate ? -75 : undefined}
-        stopLeftSwipe={175}
-        stopRightSwipe={isPrivate ? -175 : undefined}
-        keyExtractor={(item) => item.id}
-        onRightAction={isPrivate ? (data, rowMap) => deleteNote(data, rowMap) : undefined}
-        onLeftAction={(data, rowMap) => publishNote(data, rowMap)}
-        contentContainerStyle={{ paddingBottom: 150 }}
-        ListFooterComponent={renderFooter}
-      />
-    );
-  };
+  const renderList = () => (
+    <NotesList
+      notes={listData}
+      hasMore={hasMore}
+      isLoadingMore={isLoadingMore}
+      onLoadMore={handleLoadMore}
+      onBeforeEditNote={() => toggleAddNoteState()}
+      itemClassName="w-full bg-[#e6e6e6] dark:bg-black"
+      swipeActions={{
+        renderHiddenItem: sideMenu,
+        leftActivationValue: 160,
+        rightActivationValue: isPrivate ? -160 : undefined,
+        leftOpenValue: 75,
+        rightOpenValue: isPrivate ? -75 : undefined,
+        stopLeftSwipe: 175,
+        stopRightSwipe: isPrivate ? -175 : undefined,
+        onRightAction: isPrivate ? (data, rowMap) => deleteNote(data, rowMap) : undefined,
+        onLeftAction: (data, rowMap) => publishNote(data, rowMap),
+      }}
+    />
+  );
 
   const [userTutorial, setUserTutorial] = useState<boolean | null>(null);
   const [accountTip, setAccountTip] = useState(false);
@@ -467,8 +352,6 @@ const HomeScreen: React.FC = () => {
       <View testID="notes-list" className="w-full flex-1">
         {rendering ? <NoteSkeleton /> : renderList()}
       </View>
-
-      <NoteDetailModal isVisible={isModalVisible} onClose={() => setModalVisible(false)} note={selectedNote} />
 
       {isSortOpened && !isSearchVisible && (
         <View

--- a/lib/screens/Library.tsx
+++ b/lib/screens/Library.tsx
@@ -1,31 +1,24 @@
 import React, { useState, useEffect } from "react";
-import { Platform, View, Text, TouchableOpacity, Dimensions, TextInput, Animated, StatusBar, ActivityIndicator } from "react-native";
+import { Platform, View, Text, TouchableOpacity, Dimensions, TextInput, Animated, StatusBar } from "react-native";
 import { useRouter } from "expo-router";
 import { Ionicons, MaterialIcons } from "@expo/vector-icons";
 import NoteSkeleton from "../components/noteSkeleton";
-import { formatToLocalDateString } from "../components/time";
 import { useTheme } from "../components/ThemeProvider";
-import NoteDetailModal, { NoteDetailData } from "./mapPage/NoteDetailModal";
 import Greeting from "../components/Greeting";
-import NotesComponent from "../components/NotesComponent";
-import LottieView from "lottie-react-native";
+import NotesList from "../components/NotesList";
 import Tooltip from "react-native-walkthrough-tooltip";
 import TooltipContent from "../onboarding/TooltipComponent";
 import { getHasDoneTutorial, setTutorialDone } from "../utils/tutorial";
 import { useUserInfo, useNotesList, useAnimatedSearch, sortNotes, filterNotes } from "../hooks/useNotesList";
-import { SwipeListView } from "react-native-swipe-list-view";
 import Constants from "expo-constants";
 
-const TEXT_LENGTH = 18;
 const { width, height } = Dimensions.get("window");
 
 const Library = () => {
   const router = useRouter();
-  const { colors, isDarkmode, accentColor } = useTheme();
+  const { accentColor } = useTheme();
   const { userInitials, userName } = useUserInfo();
 
-  const [selectedNote, setSelectedNote] = useState<NoteDetailData | undefined>(undefined);
-  const [isModalVisible, setModalVisible] = useState(false);
   const [isSortOpened, setIsSortOpened] = useState(false);
   const [selectedSortOption, setSelectedSortOption] = useState(1);
 
@@ -35,108 +28,7 @@ const Library = () => {
 
   const displayNotes = sortNotes(filterNotes(notes, searchQuery), selectedSortOption);
 
-  const renderItem = (data: any) => {
-    const item = data.item;
-    const showTime = formatToLocalDateString(new Date(item.time));
-    const mediaItem = item.media[0];
-    const ImageType = mediaItem?.type;
-    let ImageURI = "";
-    let IsImage = false;
-    if (ImageType === "image") {
-      ImageURI = mediaItem.uri;
-      IsImage = true;
-    } else if (ImageType === "video") {
-      ImageURI = mediaItem.thumbnail;
-      IsImage = true;
-    }
-    const resolvedImageURI = Platform.OS === "android" ? String(ImageURI || "") : ImageURI;
-
-    return (
-      <TouchableOpacity
-        key={item.id}
-        testID={`note-item-${data.index}`}
-        activeOpacity={1}
-        className="bg-secondary"
-        onPress={() => {
-          if (!item.isPublished) {
-            router.push({
-              pathname: "/edit-note",
-              params: { noteData: JSON.stringify({ ...item, time: item.time instanceof Date ? item.time.toISOString() : item.time }) },
-            });
-          } else {
-            setSelectedNote({
-              ...item,
-              time: formatToLocalDateString(new Date(item.time)),
-              description: item.text,
-              images: item.media.map((m: { uri: string }) => ({ uri: m.uri })),
-            });
-            setModalVisible(true);
-          }
-        }}
-      >
-        <NotesComponent
-          IsImage={IsImage}
-          resolvedImageURI={resolvedImageURI}
-          ImageType={ImageType}
-          textLength={TEXT_LENGTH}
-          showTime={showTime}
-          item={item}
-          isPublished={item.isPublished}
-          isDarkmode={isDarkmode}
-        />
-      </TouchableOpacity>
-    );
-  };
-
-  const renderFooter = () => {
-    if (isLoadingMore) {
-      return (
-        <View className="mb-[100px] items-center py-[50px]">
-          <ActivityIndicator size="small" color={colors.foreground} />
-        </View>
-      );
-    }
-    if (hasMore) {
-      return (
-        <TouchableOpacity
-          testID="load-more"
-          onPress={handleLoadMore}
-          className="my-1 w-[65%] items-center self-center rounded-lg bg-accent py-5"
-        >
-          <Text testID="load-more-button" className="font-inter text-base font-normal text-foreground">
-            Load More
-          </Text>
-        </TouchableOpacity>
-      );
-    }
-    return (
-      <View className="items-center p-5">
-        <Text testID="empty-state-text" className="font-inter text-sm text-gray-500">
-          End of the Page
-        </Text>
-      </View>
-    );
-  };
-
-  const renderList = () => {
-    if (displayNotes.length === 0) {
-      return (
-        <View className="items-center justify-center">
-          <LottieView source={require("../../assets/animations/noResultFound.json")} autoPlay loop style={{ width: 100, height: 200 }} />
-          <Text className="font-inter text-[15px] font-normal">No Results Found</Text>
-        </View>
-      );
-    }
-    return (
-      <SwipeListView
-        data={displayNotes}
-        renderItem={renderItem}
-        keyExtractor={(item) => item.id}
-        contentContainerStyle={{ paddingBottom: isLoadingMore ? 50 : 150 }}
-        ListFooterComponent={renderFooter}
-      />
-    );
-  };
+  const renderList = () => <NotesList notes={displayNotes} hasMore={hasMore} isLoadingMore={isLoadingMore} onLoadMore={handleLoadMore} />;
 
   const [userTutorial, setUserTutorial] = useState<boolean | null>(null);
   const [libraryTip, setLibraryTip] = useState(false);
@@ -277,8 +169,6 @@ const Library = () => {
           </View>
         </View>
       )}
-
-      <NoteDetailModal isVisible={isModalVisible} onClose={() => setModalVisible(false)} note={selectedNote} />
     </View>
   );
 };


### PR DESCRIPTION
## Summary

Items 1 and 2 from the stability-pass refactor backlog. Net -102 lines with no behavior change beyond the small unifications listed below.

**Shared NotesList component** (`lib/components/NotesList.tsx`)
- HomeScreen and Library duplicated ~90% of their list code. NotesList now owns row rendering, media thumbnail resolution, the load-more footer, the empty state, NoteDetailModal, and edit-note navigation.
- HomeScreen passes its swipe publish/delete actions in; Library uses it as a plain list.
- HomeScreen: 507 -> ~390 lines. Library: 285 -> 176 lines.

**Shared note editor pieces** (`lib/hooks/useNoteLocation.ts`, `lib/hooks/useNoteEditor.ts`, `lib/components/NoteEditor.tsx`)
- `useNoteLocation`: the fetch-on-mount / toggle / (0,0)-means-off logic that was copy-pasted verbatim between AddNoteScreen and EditNoteScreen.
- `useNoteEditor`: editor bridge, theme CSS injection, image/video/audio insert helpers, done-button handler. Plus `useKeyboardVisible` and `isBodyEmpty`.
- `NoteEditorHeader` / `ActionRow` / `Panels` / `Body` components used by both screens.
- AddNoteScreen: 481 -> 285 lines. EditNoteScreen: 391 -> 236 lines.

**Unifications where the two copies had drifted** (kept the better variant in each case)
- Edit-note navigation uses the `instanceof Date` guard everywhere; HomeScreen's copy called `item.time.toISOString()` and would crash on a string time.
- EditNote audio-insert errors now surface in the editor like image/video errors do.
- AddNote's location icon uses the theme foreground color instead of hardcoded black.
- Dropped AddNote's redundant second `injectCSS` effect.

All `note-item-N` / `note-publish-btn-N` / `note-delete-btn-N` testIDs from #282 are preserved.

## Verification

- `tsc --noEmit`, `eslint`, and all 45 unit tests pass
- Maestro flows run against the refactored screens on the iOS simulator (full local backend): `auth_login`, `note_create_publish`, `note_edit_draft`, `nav_tabs` all pass