### PR TITLE
Drop keyboard-aware-scroll-view, move logout to profile, guard empty drafts

### DIFF
--- a/.maestro/auth_logout.yaml
+++ b/.maestro/auth_logout.yaml
@@ -2,21 +2,21 @@ appId: register.edu.slu.cs.oss.lrda
 ---
 # Auth flow: logout from the app.
 # Assumes we are already logged in and on the tabs screen.
+# Logout lives on the profile page, reached via the avatar on the More tab.
 
 - tapOn:
     id: "tab-more"
 - extendedWaitUntil:
     visible:
+      id: "profile-button"
+    timeout: 10000
+- tapOn:
+    id: "profile-button"
+
+- extendedWaitUntil:
+    visible:
       id: "logout-button"
     timeout: 10000
-
-# The Logout row sits underneath the floating tab bar (and its center is
-# covered by the center Add button) until the menu is scrolled up.
-- scrollUntilVisible:
-    element:
-      id: "logout-button"
-    direction: DOWN
-    centerElement: true
 - tapOn:
     id: "logout-button"
 

--- a/.maestro/note_discard_empty.yaml
+++ b/.maestro/note_discard_empty.yaml
@@ -1,0 +1,31 @@
+appId: register.edu.slu.cs.oss.lrda
+---
+# Note flow: open the note editor via the center tab button and back out
+# without entering anything. No empty "Untitled" draft should be saved.
+# Assumes a logged-in session whose private notes contain no "Untitled" notes.
+
+- launchApp
+
+- runFlow: skip_tutorial.yaml
+
+# Open the note editor via the center tab button
+- tapOn:
+    id: "fab-button"
+- extendedWaitUntil:
+    visible: "Title Field Note"
+    timeout: 15000
+- runFlow: skip_tutorial.yaml
+
+# Back out immediately; the empty draft is discarded
+- tapOn:
+    id: "note-back-button"
+- extendedWaitUntil:
+    visible:
+      id: "HomeScreen"
+    timeout: 15000
+
+# The private list must not have gained an "Untitled" draft
+- tapOn:
+    id: "private-btn"
+- waitForAnimationToEnd
+- assertNotVisible: ".*Untitled.*"

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -2,6 +2,7 @@ import { Tabs } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { Platform } from "react-native";
 import { useTheme } from "../../lib/components/ThemeProvider";
+import { TAB_BAR_HEIGHT } from "../../lib/constants";
 import AddNoteBtnComponent from "../../lib/components/AddNoteBtnComponent";
 
 export default function TabsLayout() {
@@ -19,7 +20,7 @@ export default function TabsLayout() {
           bottom: 0,
           left: 0,
           right: 0,
-          height: Platform.OS === "ios" ? 80 : 70,
+          height: TAB_BAR_HEIGHT,
           paddingBottom: Platform.OS === "ios" ? 30 : 20,
           borderTopWidth: 0,
           elevation: 0,

--- a/lib/components/NoteEditor.tsx
+++ b/lib/components/NoteEditor.tsx
@@ -26,7 +26,11 @@ export function NoteEditorHeader({ title, onChangeTitle, onBack, onTitleFocus, r
       className={`flex-row items-center justify-between px-[5px] text-center ${rowClassName}`}
       style={{ paddingTop: Constants.statusBarHeight, height: height * 0.15 }}
     >
-      <TouchableOpacity className="z-[99] h-[50px] w-[50px] items-center justify-center rounded-full bg-tertiary" onPress={onBack}>
+      <TouchableOpacity
+        testID="note-back-button"
+        className="z-[99] h-[50px] w-[50px] items-center justify-center rounded-full bg-tertiary"
+        onPress={onBack}
+      >
         <Ionicons name="arrow-back-outline" size={30} color="var(--color-foreground)" />
       </TouchableOpacity>
       <TextInput

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,6 @@
+import { Platform } from "react-native";
+
+// Height of the floating tab bar in app/(tabs)/_layout.tsx. Screens inside the
+// tab navigator use this to keep interactive content from resting underneath
+// the bar, where the transparent center slot lets the Add button steal taps.
+export const TAB_BAR_HEIGHT = Platform.OS === "ios" ? 80 : 70;

--- a/lib/screens/AddNoteScreen.tsx
+++ b/lib/screens/AddNoteScreen.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useEffectEvent, useRef, useState } from "react";
-import { View, TouchableOpacity, Platform, KeyboardAvoidingView, Modal, Text, StatusBar } from "react-native";
+import { View, TouchableOpacity, Platform, KeyboardAvoidingView, Modal, ScrollView, Text, StatusBar } from "react-native";
 import ToastMessage from "react-native-toast-message";
 
 import { DEFAULT_TOOLBAR_ITEMS, Toolbar } from "@10play/tentap-editor";
 import LoadingModal from "../components/LoadingModal";
 import { NoteEditorHeader, NoteEditorActionRow, NoteEditorPanels, NoteEditorBody } from "../components/NoteEditor";
-import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { VideoView, useVideoPlayer } from "expo-video";
 import { getHasDoneTutorial, setTutorialDone } from "../utils/tutorial";
 import type { AudioType, Media } from "../models/media_class";
@@ -73,24 +72,24 @@ const AddNoteScreen: React.FC = () => {
     isPublishedRef.current = isPublished;
   }, [isPublished]);
 
+  const hasNoteContent = () =>
+    titleTxtRef.current.length !== 0 ||
+    !isBodyEmpty(bodyTextRef.current) ||
+    tagsRef.current.length !== 0 ||
+    mediaRef.current.length !== 0 ||
+    audioRef.current.length !== 0;
+
+  // Single exit path: leaving the screen (back button or tab switch) fires this
+  // blur handler, which saves only when the note has content — otherwise the
+  // draft is discarded so backing out doesn't accumulate empty "Untitled" notes.
   const onBlur = useEffectEvent(async () => {
     if (!isPublishedRef.current) {
-      const latestContent = await editor.getHTML();
-      bodyTextRef.current = latestContent;
+      bodyTextRef.current = await editor.getHTML();
 
-      const bodyIsEmpty = isBodyEmpty(latestContent);
-
-      if (
-        titleTxtRef.current.length !== 0 ||
-        !bodyIsEmpty ||
-        tagsRef.current.length !== 0 ||
-        mediaRef.current.length !== 0 ||
-        audioRef.current.length !== 0
-      ) {
-        await saveNote(false);
+      if (hasNoteContent()) {
+        await saveNote(false, false);
       } else {
         toggleAddNoteState();
-        router.back();
       }
     }
   });
@@ -103,8 +102,6 @@ const AddNoteScreen: React.FC = () => {
     return unsubscribe;
   }, [navigation]);
 
-  const scrollViewRef = useRef<KeyboardAwareScrollView>(null);
-
   const onPublish = useEffectEvent(() => handleShareButtonPress());
 
   useEffect(() => {
@@ -114,15 +111,7 @@ const AddNoteScreen: React.FC = () => {
   const handleShareButtonPress = async () => {
     await syncEditorContent();
 
-    const bodyIsEmpty = isBodyEmpty(bodyTextRef.current);
-
-    if (
-      titleTxtRef.current.length !== 0 ||
-      !bodyIsEmpty ||
-      tagsRef.current.length !== 0 ||
-      mediaRef.current.length !== 0 ||
-      audioRef.current.length !== 0
-    ) {
+    if (hasNoteContent()) {
       setIsPublished(!isPublished);
       ToastMessage.show({
         type: "success",
@@ -155,12 +144,12 @@ const AddNoteScreen: React.FC = () => {
     };
   };
 
-  const saveNote = async (published: boolean) => {
+  const saveNote = async (published: boolean, navigateBack: boolean = true) => {
     const noteData = await prepareNoteData(published);
 
     try {
       await createNoteMutation.mutateAsync(noteData);
-      if (router.canGoBack()) {
+      if (navigateBack && router.canGoBack()) {
         router.back();
       }
     } catch (error) {
@@ -188,14 +177,7 @@ const AddNoteScreen: React.FC = () => {
   return (
     <View className="flex-1">
       <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"} className="flex-1">
-        <KeyboardAwareScrollView
-          ref={scrollViewRef}
-          contentContainerStyle={{ flexGrow: 1 }}
-          enableOnAndroid
-          extraScrollHeight={Platform.OS === "ios" ? 80 : 100}
-          keyboardOpeningTime={0}
-          keyboardShouldPersistTaps="handled"
-        >
+        <ScrollView contentContainerStyle={{ flexGrow: 1 }} keyboardShouldPersistTaps="handled">
           <View className="flex-1">
             <Tooltip
               topAdjustment={Platform.OS === "android" ? -(StatusBar.currentHeight ?? 0) : 0}
@@ -222,7 +204,7 @@ const AddNoteScreen: React.FC = () => {
                 <NoteEditorHeader
                   title={titleText}
                   onChangeTitle={setTitleText}
-                  onBack={() => saveNote(false)}
+                  onBack={() => router.back()}
                   onTitleFocus={() => {
                     if (editor?.blur) {
                       editor.blur();
@@ -267,7 +249,7 @@ const AddNoteScreen: React.FC = () => {
               </TouchableOpacity>
             </View>
           )}
-        </KeyboardAwareScrollView>
+        </ScrollView>
         <Modal animationType="slide" transparent={true} visible={isVideoModalVisible} onRequestClose={() => setIsVideoModalVisible(false)}>
           <View className="flex-1 items-center justify-center bg-black/50">
             <View className="w-[90%] items-center rounded-[10px] bg-white p-5">

--- a/lib/screens/EditNoteScreen.tsx
+++ b/lib/screens/EditNoteScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useEffectEvent, useRef, useMemo } from "react";
-import { View, TouchableOpacity, KeyboardAvoidingView, Platform, Text } from "react-native";
+import { View, TouchableOpacity, KeyboardAvoidingView, Platform, ScrollView, Text } from "react-native";
 import ToastMessage from "react-native-toast-message";
 import { useAuthStore } from "../stores/authStore";
 import type { Media, AudioType } from "../models/media_class";
@@ -11,7 +11,6 @@ import LoadingModal from "../components/LoadingModal";
 import { NoteEditorHeader, NoteEditorActionRow, NoteEditorPanels, NoteEditorBody } from "../components/NoteEditor";
 import { useAddNoteContext } from "../context/AddNoteContext";
 import { useAddNoteStore } from "../stores/addNoteStore";
-import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { useRouter, useLocalSearchParams, useNavigation } from "expo-router";
 
 const EditNoteScreen = () => {
@@ -54,8 +53,6 @@ const EditNoteScreen = () => {
   useEffect(() => {
     setPublishNote(() => onPublish);
   }, [setPublishNote]);
-
-  const scrollViewRef = useRef(null);
 
   const handlePublishPress = async () => {
     const latestContent = await editor.getHTML();
@@ -168,7 +165,7 @@ const EditNoteScreen = () => {
         keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 0}
         className="flex-1"
       >
-        <KeyboardAwareScrollView ref={scrollViewRef} contentContainerStyle={{ flexGrow: 1 }} keyboardShouldPersistTaps="handled">
+        <ScrollView contentContainerStyle={{ flexGrow: 1 }} keyboardShouldPersistTaps="handled">
           <View className="min-h-[140px] bg-accent">
             <NoteEditorHeader title={title} onChangeTitle={setTitle} onBack={handleSaveNote} rowClassName="bg-primary" />
             <NoteEditorActionRow
@@ -214,7 +211,7 @@ const EditNoteScreen = () => {
               <Toolbar editor={editor} items={DEFAULT_TOOLBAR_ITEMS} />
             </View>
           )}
-        </KeyboardAwareScrollView>
+        </ScrollView>
 
         <LoadingModal visible={updateNoteMutation.isPending} />
       </KeyboardAvoidingView>

--- a/lib/screens/MorePage.tsx
+++ b/lib/screens/MorePage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 import { View, Text, ScrollView, TouchableOpacity, Image, Dimensions, Platform, StatusBar, Linking } from "react-native";
 import { Ionicons, Feather, MaterialIcons, Entypo } from "@expo/vector-icons";
 import { useTheme } from "../components/ThemeProvider";
-import { useThemeStore } from "../stores/themeStore";
 import { useAuthStore } from "../stores/authStore";
 import { getHasDoneTutorial, setTutorialDone } from "../utils/tutorial";
 import { useRouter } from "expo-router";
@@ -12,6 +11,7 @@ import ReactNativeModal from "react-native-modal";
 import AppThemeSelectorScreen from "./AppThemeSelectorScreen";
 import Tooltip from "react-native-walkthrough-tooltip";
 import TooltipContent from "../onboarding/TooltipComponent";
+import { TAB_BAR_HEIGHT } from "../constants";
 const { width, height } = Dimensions.get("window");
 const data = [
   { source: require("../../assets/Pond_395.jpg") },
@@ -21,9 +21,7 @@ const data = [
 
 export default function MorePage() {
   const { isDarkmode, toggleDarkmode, accentColor } = useTheme();
-  const resetTheme = useThemeStore((state) => state.reset);
   const user = useAuthStore((s) => s.user);
-  const logout = useAuthStore((s) => s.logout);
   const router = useRouter();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isThemeOpen, setIsThemeOpen] = useState(false);
@@ -47,16 +45,6 @@ export default function MorePage() {
   const handleSettingsToggle = () => {
     setIsSettingsOpen(!isSettingsOpen);
   };
-  const onLogoutPress = async () => {
-    try {
-      await logout();
-      resetTheme();
-      router.replace("/(auth)/login");
-    } catch (e) {
-      console.log(e);
-    }
-  };
-
   const handleReportClick = () => {
     const email = "yashkamal.bhatia@slu.edu";
     const subject = "Bug Report on 'Where's Religion?";
@@ -148,6 +136,7 @@ export default function MorePage() {
             >
               <View className="flex-row items-center justify-between" style={{ width: width > 500 ? "13%" : "27%" }}>
                 <TouchableOpacity
+                  testID="profile-button"
                   className="ml-2 items-center justify-center rounded-full bg-foreground"
                   style={{
                     width: width > 1000 ? 50 : 30,
@@ -166,7 +155,8 @@ export default function MorePage() {
           </View>
 
           <ScrollView
-            contentContainerStyle={{ alignItems: "center", paddingBottom: 200 }}
+            style={{ marginBottom: TAB_BAR_HEIGHT }}
+            contentContainerStyle={{ alignItems: "center", paddingBottom: 24 }}
             scrollEnabled={true}
             showsVerticalScrollIndicator={false}
           >
@@ -190,7 +180,7 @@ export default function MorePage() {
               topAdjustment={Platform.OS === "android" ? -(StatusBar.currentHeight ?? 0) : 0}
               content={
                 <TooltipContent
-                  message="Welcome to our more page! Here you can find settings, FAQ, logout, switch themes, and more!"
+                  message="Welcome to our more page! Here you can find settings, FAQ, switch themes, and more!"
                   onPressOk={() => {
                     setUserTutorial(true);
                     setMorePageTip(false);
@@ -217,7 +207,6 @@ export default function MorePage() {
                 <MenuItem title="Meet our team" iconName="people-outline" onPress={() => router.push("/more/team")} />
                 <MenuItem title="Settings" iconName="settings-outline" onPress={handleSettingsToggle} />
                 <MenuItem title="FAQ" iconName="help-circle-outline" onPress={() => {}} />
-                <MenuItem title="Logout" iconName="exit-outline" onPress={onLogoutPress} testID="logout-button" />
               </View>
             </Tooltip>
           </ScrollView>

--- a/lib/screens/ProfilePage.tsx
+++ b/lib/screens/ProfilePage.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { Text, View, SafeAreaView, Image, FlatList, TouchableOpacity, ActivityIndicator } from "react-native";
 import { useQuery } from "@tanstack/react-query";
 import { useAuthStore } from "../stores/authStore";
+import { useThemeStore } from "../stores/themeStore";
 import { Note } from "../../types";
 import DataConversion from "../utils/data_conversion";
 import { fetchAllNotes } from "../utils/api_calls";
@@ -12,6 +13,18 @@ import { useRouter } from "expo-router";
 export default function ProfilePage() {
   const navigation = useRouter();
   const authUser = useAuthStore((s) => s.user);
+  const logout = useAuthStore((s) => s.logout);
+  const resetTheme = useThemeStore((state) => state.reset);
+
+  const onLogoutPress = async () => {
+    try {
+      await logout();
+      resetTheme();
+      navigation.replace("/(auth)/login");
+    } catch (e) {
+      console.log(e);
+    }
+  };
 
   const userName = authUser?.name ?? "";
   const userInitials = useMemo(() => {
@@ -56,9 +69,20 @@ export default function ProfilePage() {
           contentContainerStyle={{ paddingBottom: 200 }}
           ListHeaderComponent={() => (
             <View>
-              <TouchableOpacity onPress={() => navigation.back()}>
-                <Feather name={"arrow-left"} size={30} style={{ marginLeft: 20 }} />
-              </TouchableOpacity>
+              <View className="flex-row items-center justify-between px-5">
+                <TouchableOpacity onPress={() => navigation.back()}>
+                  <Feather name={"arrow-left"} size={30} />
+                </TouchableOpacity>
+                <TouchableOpacity
+                  testID="logout-button"
+                  accessibilityLabel="Logout"
+                  className="flex-row items-center"
+                  onPress={onLogoutPress}
+                >
+                  <Text className="mr-2 font-inter text-sm font-medium text-foreground">Logout</Text>
+                  <Feather name={"log-out"} size={24} />
+                </TouchableOpacity>
+              </View>
               <View className="self-center">
                 <View className="h-[190px] w-[190px] content-center justify-center rounded-full bg-foreground">
                   <Text className="self-center text-[60px] font-medium text-primary">{userInitials}</Text>

--- a/lib/screens/loginScreens/ForgotPassword.tsx
+++ b/lib/screens/loginScreens/ForgotPassword.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
-import { Text, View, TextInput, TouchableOpacity, Alert, ImageBackground } from "react-native";
+import { Text, View, TextInput, TouchableOpacity, Alert, ImageBackground, KeyboardAvoidingView, Platform, ScrollView } from "react-native";
 import { authClient, AUTH_API_URL } from "../../auth/client";
-import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { useRouter } from "expo-router";
 import { validateEmail as checkEmail } from "../../utils/validation";
 
@@ -45,44 +44,46 @@ const ForgotPassword: React.FC = () => {
   };
 
   return (
-    <KeyboardAwareScrollView
-      contentContainerStyle={{ flex: 1, justifyContent: "center", alignItems: "stretch" }}
-      style={{ backgroundColor: "#F4DFCD" }}
-      keyboardShouldPersistTaps="handled"
-    >
-      <ImageBackground source={require("../../../assets/splash.jpg")} className="flex-1 justify-center" resizeMode="cover">
-        <View
-          className="h-[400px] w-[300px] items-center self-center rounded-[10px] bg-white/85 p-5"
-          style={{ elevation: 10, shadowColor: "#000", shadowOpacity: 0.4, shadowRadius: 10 }}
-        >
-          <Text className="mb-5 text-[28px] font-bold text-[#111111]">Forgot Password</Text>
-          <Text className="mb-5 text-center text-[16px] text-[#555555]">Enter your email to receive a password reset link.</Text>
-          <View className="mb-5 h-[50px] w-full justify-center rounded-full border border-gray-500 bg-white px-5">
-            <TextInput
-              className="h-[50px] w-full rounded-full text-[16px] text-[#111111]"
-              placeholder="Email..."
-              placeholderTextColor="#003f5c"
-              value={email}
-              onChangeText={(text) => setEmail(text)}
-              keyboardType="email-address"
-              autoCapitalize="none"
-            />
-          </View>
-          <TouchableOpacity
-            onPress={handlePasswordReset}
-            className="mb-[10px] h-[50px] w-[200px] items-center justify-center rounded-[30px] shadow-sm"
-            style={{ backgroundColor: "rgb(17,47,187)", elevation: 10, shadowColor: "#000", shadowOpacity: 0.2, shadowRadius: 3 }}
+    <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"} className="flex-1">
+      <ScrollView
+        contentContainerStyle={{ flexGrow: 1, justifyContent: "center", alignItems: "stretch" }}
+        style={{ backgroundColor: "#F4DFCD" }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <ImageBackground source={require("../../../assets/splash.jpg")} className="flex-1 justify-center" resizeMode="cover">
+          <View
+            className="h-[400px] w-[300px] items-center self-center rounded-[10px] bg-white/85 p-5"
+            style={{ elevation: 10, shadowColor: "#000", shadowOpacity: 0.4, shadowRadius: 10 }}
           >
-            <Text className="text-[15px] font-semibold text-white">Send Reset Link</Text>
-          </TouchableOpacity>
-          <TouchableOpacity className="mt-5" onPress={() => router.back()}>
-            <Text className="text-[16px] font-bold" style={{ color: "rgb(17,47,187)" }}>
-              Back to Login
-            </Text>
-          </TouchableOpacity>
-        </View>
-      </ImageBackground>
-    </KeyboardAwareScrollView>
+            <Text className="mb-5 text-[28px] font-bold text-[#111111]">Forgot Password</Text>
+            <Text className="mb-5 text-center text-[16px] text-[#555555]">Enter your email to receive a password reset link.</Text>
+            <View className="mb-5 h-[50px] w-full justify-center rounded-full border border-gray-500 bg-white px-5">
+              <TextInput
+                className="h-[50px] w-full rounded-full text-[16px] text-[#111111]"
+                placeholder="Email..."
+                placeholderTextColor="#003f5c"
+                value={email}
+                onChangeText={(text) => setEmail(text)}
+                keyboardType="email-address"
+                autoCapitalize="none"
+              />
+            </View>
+            <TouchableOpacity
+              onPress={handlePasswordReset}
+              className="mb-[10px] h-[50px] w-[200px] items-center justify-center rounded-[30px] shadow-sm"
+              style={{ backgroundColor: "rgb(17,47,187)", elevation: 10, shadowColor: "#000", shadowOpacity: 0.2, shadowRadius: 3 }}
+            >
+              <Text className="text-[15px] font-semibold text-white">Send Reset Link</Text>
+            </TouchableOpacity>
+            <TouchableOpacity className="mt-5" onPress={() => router.back()}>
+              <Text className="text-[16px] font-bold" style={{ color: "rgb(17,47,187)" }}>
+                Back to Login
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </ImageBackground>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 };
 

--- a/lib/screens/loginScreens/LoginScreen.tsx
+++ b/lib/screens/loginScreens/LoginScreen.tsx
@@ -1,7 +1,18 @@
 import * as SplashScreen from "expo-splash-screen";
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { ActivityIndicator, Animated, ImageBackground, Keyboard, Text, TextInput, TouchableOpacity, View } from "react-native";
-import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
+import {
+  ActivityIndicator,
+  Animated,
+  ImageBackground,
+  Keyboard,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import Toast from "react-native-toast-message";
 import { useAuthStore } from "../../stores/authStore";
 import { useRouter } from "expo-router";
@@ -78,75 +89,77 @@ const LoginScreen: React.FC = () => {
   };
 
   return (
-    <KeyboardAwareScrollView
-      contentContainerStyle={{ flex: 1, justifyContent: "center", alignItems: "stretch" }}
-      style={{ backgroundColor: "#F4DFCD" }}
-      keyboardShouldPersistTaps="handled"
-    >
-      <ImageBackground source={require("../../../assets/splash.jpg")} className="flex-1 justify-center" resizeMode="cover">
-        {firstClick ? (
-          <TouchableOpacity activeOpacity={1} className="mb-[200px] items-center justify-center self-center py-[200px]" onPress={fadeOut}>
-            <Animated.Text className="mb-[70px] font-inter text-[50px] font-bold text-[#111111]" style={{ opacity: fadeAnim }}>
-              Where&apos;s {"\n"} Religion?
-            </Animated.Text>
-          </TouchableOpacity>
-        ) : (
-          <View
-            className="h-[500px] w-[300px] items-center justify-center self-center rounded-[10px] bg-white/60 shadow-md"
-            style={{ elevation: 10, shadowColor: "#000", shadowOpacity: 0.4, shadowRadius: 10 }}
-          >
-            <Text className="mb-[50px] font-inter text-[50px] font-bold text-[#111111]">Login</Text>
-            <View className="mb-5 h-[50px] w-4/5 items-start justify-center rounded-full border-2 border-gray-500 bg-white p-5">
-              <TextInput
-                className="h-[50px] w-full rounded-full font-inter text-[16px] text-[#111111]"
-                placeholder="Email..."
-                placeholderTextColor="#003f5c"
-                value={username}
-                onChangeText={(text) => setUsername(text)}
-                onSubmitEditing={handleLogin}
-                testID="email-input"
-                autoCapitalize="none"
-              />
-            </View>
-
-            <View className="mb-5 h-[50px] w-4/5 items-start justify-center rounded-full border-2 border-gray-500 bg-white p-5">
-              <TextInput
-                secureTextEntry
-                className="h-[50px] w-full rounded-full font-inter text-[16px] text-[#111111]"
-                placeholder="Password..."
-                placeholderTextColor="#003f5c"
-                value={password}
-                onChangeText={(text) => setPassword(text)}
-                onSubmitEditing={handleLogin}
-                testID="password-input"
-              />
-            </View>
-            <TouchableOpacity onPress={() => router.push("/(auth)/forgot-password")}>
-              <View className="w-[300px] items-end justify-center">
-                <Text className="mb-5 mr-10 text-[12px] font-normal text-[#111111]">Forgot Password?</Text>
+    <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"} className="flex-1">
+      <ScrollView
+        contentContainerStyle={{ flexGrow: 1, justifyContent: "center", alignItems: "stretch" }}
+        style={{ backgroundColor: "#F4DFCD" }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <ImageBackground source={require("../../../assets/splash.jpg")} className="flex-1 justify-center" resizeMode="cover">
+          {firstClick ? (
+            <TouchableOpacity activeOpacity={1} className="mb-[200px] items-center justify-center self-center py-[200px]" onPress={fadeOut}>
+              <Animated.Text className="mb-[70px] font-inter text-[50px] font-bold text-[#111111]" style={{ opacity: fadeAnim }}>
+                Where&apos;s {"\n"} Religion?
+              </Animated.Text>
+            </TouchableOpacity>
+          ) : (
+            <View
+              className="h-[500px] w-[300px] items-center justify-center self-center rounded-[10px] bg-white/60 shadow-md"
+              style={{ elevation: 10, shadowColor: "#000", shadowOpacity: 0.4, shadowRadius: 10 }}
+            >
+              <Text className="mb-[50px] font-inter text-[50px] font-bold text-[#111111]">Login</Text>
+              <View className="mb-5 h-[50px] w-4/5 items-start justify-center rounded-full border-2 border-gray-500 bg-white p-5">
+                <TextInput
+                  className="h-[50px] w-full rounded-full font-inter text-[16px] text-[#111111]"
+                  placeholder="Email..."
+                  placeholderTextColor="#003f5c"
+                  value={username}
+                  onChangeText={(text) => setUsername(text)}
+                  onSubmitEditing={handleLogin}
+                  testID="email-input"
+                  autoCapitalize="none"
+                />
               </View>
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={onLoginPress}
-              className="mb-[10px] h-[50px] w-[200px] items-center justify-center rounded-[30px] shadow-sm"
-              style={{ backgroundColor: "rgb(17,47,187)", elevation: 10, shadowColor: "#000", shadowOpacity: 0.2, shadowRadius: 3 }}
-              testID="login-button"
-            >
-              {!loading && <Text className="font-inter text-[15px] font-semibold text-white">Login</Text>}
-              {loading && <ActivityIndicator size="small" color="white" />}
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={handleGoRegister}
-              className="mb-[10px] h-[50px] w-[200px] items-center justify-center rounded-[30px] shadow-sm"
-              style={{ backgroundColor: "rgb(17,47,187)", elevation: 10, shadowColor: "#000", shadowOpacity: 0.2, shadowRadius: 3 }}
-              testID="register-button"
-            >
-              <Text className="font-inter text-[15px] font-semibold text-white">Register</Text>
-            </TouchableOpacity>
-          </View>
-        )}
-      </ImageBackground>
-    </KeyboardAwareScrollView>
+
+              <View className="mb-5 h-[50px] w-4/5 items-start justify-center rounded-full border-2 border-gray-500 bg-white p-5">
+                <TextInput
+                  secureTextEntry
+                  className="h-[50px] w-full rounded-full font-inter text-[16px] text-[#111111]"
+                  placeholder="Password..."
+                  placeholderTextColor="#003f5c"
+                  value={password}
+                  onChangeText={(text) => setPassword(text)}
+                  onSubmitEditing={handleLogin}
+                  testID="password-input"
+                />
+              </View>
+              <TouchableOpacity onPress={() => router.push("/(auth)/forgot-password")}>
+                <View className="w-[300px] items-end justify-center">
+                  <Text className="mb-5 mr-10 text-[12px] font-normal text-[#111111]">Forgot Password?</Text>
+                </View>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={onLoginPress}
+                className="mb-[10px] h-[50px] w-[200px] items-center justify-center rounded-[30px] shadow-sm"
+                style={{ backgroundColor: "rgb(17,47,187)", elevation: 10, shadowColor: "#000", shadowOpacity: 0.2, shadowRadius: 3 }}
+                testID="login-button"
+              >
+                {!loading && <Text className="font-inter text-[15px] font-semibold text-white">Login</Text>}
+                {loading && <ActivityIndicator size="small" color="white" />}
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={handleGoRegister}
+                className="mb-[10px] h-[50px] w-[200px] items-center justify-center rounded-[30px] shadow-sm"
+                style={{ backgroundColor: "rgb(17,47,187)", elevation: 10, shadowColor: "#000", shadowOpacity: 0.2, shadowRadius: 3 }}
+                testID="register-button"
+              >
+                <Text className="font-inter text-[15px] font-semibold text-white">Register</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+        </ImageBackground>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 };
 

--- a/lib/screens/loginScreens/RegisterScreen.tsx
+++ b/lib/screens/loginScreens/RegisterScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-import { Text, View, TextInput, TouchableOpacity, ImageBackground } from "react-native";
-import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
+import { Text, View, TextInput, TouchableOpacity, ImageBackground, KeyboardAvoidingView, Platform, ScrollView } from "react-native";
 import Toast from "react-native-toast-message";
 import { authClient } from "../../auth/client";
 import { validateEmail, validatePassword } from "../../utils/validation";
@@ -65,65 +64,67 @@ const RegistrationScreen: React.FC = () => {
   };
 
   return (
-    <KeyboardAwareScrollView contentContainerStyle={{ flex: 1, justifyContent: "center" }}>
-      <ImageBackground source={require("../../../assets/splash.jpg")} className="flex-1 justify-center" resizeMode="cover">
-        <View className="w-[85%] self-center rounded-[10px] bg-white/80 p-[25px]">
-          <Text className="pl-[10px] pt-[10px] text-left font-inter text-[32px] font-bold text-black">Register</Text>
-          <View className="mt-10">
-            <TextInput
-              className="mb-10 border-b border-black pb-[7px] pl-[10px] text-[14px] text-black"
-              placeholder="First Name"
-              placeholderTextColor="#7D7D7D"
-              value={firstName}
-              onChangeText={setFirstName}
-            />
-            <TextInput
-              className="mb-10 border-b border-black pb-[7px] pl-[10px] text-[14px] text-black"
-              placeholder="Last Name"
-              placeholderTextColor="#7D7D7D"
-              value={lastName}
-              onChangeText={setLastName}
-            />
-            <TextInput
-              className="mb-10 border-b border-black pb-[7px] pl-[10px] text-[14px] text-black"
-              placeholder="Email"
-              placeholderTextColor="#7D7D7D"
-              value={email}
-              onChangeText={setEmail}
-            />
-            <TextInput
-              className="mb-10 border-b border-black pb-[7px] pl-[10px] text-[14px] text-black"
-              placeholder="Password"
-              secureTextEntry
-              placeholderTextColor="#7D7D7D"
-              value={password}
-              onChangeText={setPassword}
-            />
-            <TextInput
-              className="mb-10 border-b border-black pb-[7px] pl-[10px] text-[14px] text-black"
-              placeholder="Confirm Password"
-              secureTextEntry
-              placeholderTextColor="#7D7D7D"
-              value={confirmPassword}
-              onChangeText={setConfirmPassword}
-            />
-          </View>
-          <TouchableOpacity
-            onPress={handleRegister}
-            className="mt-5 items-center rounded-[15px] py-[10px]"
-            style={{ backgroundColor: "rgb(17,47,187)" }}
-          >
-            <Text className="font-inter text-[22px] font-bold text-white">Sign Up</Text>
-          </TouchableOpacity>
-          <Text className="mt-5 text-center font-inter text-[14px] text-black">
-            Already have an account?{" "}
-            <Text className="font-inter font-bold" style={{ color: "rgb(17,47,187)" }} onPress={() => router.replace("/(auth)/login")}>
-              Sign In
+    <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"} className="flex-1">
+      <ScrollView contentContainerStyle={{ flexGrow: 1, justifyContent: "center" }} keyboardShouldPersistTaps="handled">
+        <ImageBackground source={require("../../../assets/splash.jpg")} className="flex-1 justify-center" resizeMode="cover">
+          <View className="w-[85%] self-center rounded-[10px] bg-white/80 p-[25px]">
+            <Text className="pl-[10px] pt-[10px] text-left font-inter text-[32px] font-bold text-black">Register</Text>
+            <View className="mt-10">
+              <TextInput
+                className="mb-10 border-b border-black pb-[7px] pl-[10px] text-[14px] text-black"
+                placeholder="First Name"
+                placeholderTextColor="#7D7D7D"
+                value={firstName}
+                onChangeText={setFirstName}
+              />
+              <TextInput
+                className="mb-10 border-b border-black pb-[7px] pl-[10px] text-[14px] text-black"
+                placeholder="Last Name"
+                placeholderTextColor="#7D7D7D"
+                value={lastName}
+                onChangeText={setLastName}
+              />
+              <TextInput
+                className="mb-10 border-b border-black pb-[7px] pl-[10px] text-[14px] text-black"
+                placeholder="Email"
+                placeholderTextColor="#7D7D7D"
+                value={email}
+                onChangeText={setEmail}
+              />
+              <TextInput
+                className="mb-10 border-b border-black pb-[7px] pl-[10px] text-[14px] text-black"
+                placeholder="Password"
+                secureTextEntry
+                placeholderTextColor="#7D7D7D"
+                value={password}
+                onChangeText={setPassword}
+              />
+              <TextInput
+                className="mb-10 border-b border-black pb-[7px] pl-[10px] text-[14px] text-black"
+                placeholder="Confirm Password"
+                secureTextEntry
+                placeholderTextColor="#7D7D7D"
+                value={confirmPassword}
+                onChangeText={setConfirmPassword}
+              />
+            </View>
+            <TouchableOpacity
+              onPress={handleRegister}
+              className="mt-5 items-center rounded-[15px] py-[10px]"
+              style={{ backgroundColor: "rgb(17,47,187)" }}
+            >
+              <Text className="font-inter text-[22px] font-bold text-white">Sign Up</Text>
+            </TouchableOpacity>
+            <Text className="mt-5 text-center font-inter text-[14px] text-black">
+              Already have an account?{" "}
+              <Text className="font-inter font-bold" style={{ color: "rgb(17,47,187)" }} onPress={() => router.replace("/(auth)/login")}>
+                Sign In
+              </Text>
             </Text>
-          </Text>
-        </View>
-      </ImageBackground>
-    </KeyboardAwareScrollView>
+          </View>
+        </ImageBackground>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 };
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "react-native-draggable-flatlist": "^4.0.1",
     "react-native-gesture-handler": "~2.31.2",
     "react-native-image-viewing": "^0.2.2",
-    "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-maps": "1.27.2",
     "react-native-modal": "^13.0.1",
     "react-native-onboarding-swiper": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,9 +128,6 @@ importers:
       react-native-image-viewing:
         specifier: ^0.2.2
         version: 0.2.2(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
-      react-native-keyboard-aware-scroll-view:
-        specifier: ^0.9.5
-        version: 0.9.5(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))
       react-native-maps:
         specifier: 1.27.2
         version: 1.27.2(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
@@ -5104,21 +5101,11 @@ packages:
       react: '>=16.11.0'
       react-native: '>=0.61.3'
 
-  react-native-iphone-x-helper@1.3.1:
-    resolution: {integrity: sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==}
-    peerDependencies:
-      react-native: '>=0.42.0'
-
   react-native-is-edge-to-edge@1.3.1:
     resolution: {integrity: sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA==}
     peerDependencies:
       react: '*'
       react-native: '*'
-
-  react-native-keyboard-aware-scroll-view@0.9.5:
-    resolution: {integrity: sha512-XwfRn+T/qBH9WjTWIBiJD2hPWg0yJvtaEw6RtPCa5/PYHabzBaWxYBOl0usXN/368BL1XktnZPh8C2lmTpOREA==}
-    peerDependencies:
-      react-native: '>=0.48.4'
 
   react-native-maps@1.27.2:
     resolution: {integrity: sha512-VKr+xZ2RZGHHJlY6KhlafvGSmK0dq/tUu5uhfJ7K9rwN5pUdubdugzMKGDU/16lXmQSg7xbClKhRctj3Pm5F5g==}
@@ -12009,20 +11996,10 @@ snapshots:
       react: 19.2.3
       react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3)
 
-  react-native-iphone-x-helper@1.3.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3)):
-    dependencies:
-      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3)
-
   react-native-is-edge-to-edge@1.3.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3)
-
-  react-native-keyboard-aware-scroll-view@0.9.5(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3)):
-    dependencies:
-      prop-types: 15.8.1
-      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3)
-      react-native-iphone-x-helper: 1.3.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))
 
   react-native-maps@1.27.2(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:


### PR DESCRIPTION
## Summary

Knocks out the remaining items from the stability-pass refactor backlog, plus one UX change.

- **Remove react-native-keyboard-aware-scroll-view** (unmaintained since ~2020, -45 transitive packages). Login, Register, and Forgot Password now use the built-in KeyboardAvoidingView + ScrollView. The note editors already wrapped everything in a KeyboardAvoidingView, so the library there was redundant double keyboard handling and became a plain ScrollView.
- **More page tap-target fix.** The bottom menu row used to rest under the floating tab bar, where the transparent center slot let the Add button steal its taps. The scroll viewport is now bounded above the bar using a shared TAB_BAR_HEIGHT constant (new lib/constants.ts, also used by the tab layout).
- **Logout moved from the More menu into the profile page header** (reached via the More page avatar). The avatar got a profile-button testID and auth_logout.yaml navigates the new path.
- **No more empty "Untitled" drafts.** The editor back arrow called saveNote unconditionally; only the blur handler had a content guard. The back arrow now just navigates and the blur handler is the single exit path: save if there is any title/body/tags/media/audio, discard otherwise. This also removes a latent double-save (back arrow and blur handler could each save the note and double-toggle the FAB state).

## Testing

- tsc, eslint, and all 45 unit tests pass.
- Full Maestro suite green on the iOS simulator against the local Hono API: auth_login (full typed login through the new keyboard handling), nav_tabs, note_discard_empty (new flow; DB confirmed no note row created), note_edit_draft, note_create_publish (DB confirmed exactly one note, no duplicates), auth_logout via the profile page.
- Visually confirmed the More page menu ends above the tab bar.