### PR TITLE
Make Maestro suite order-independent, document real iOS scroller behavior

### DIFF
--- a/.maestro/auth_forgot_password.yaml
+++ b/.maestro/auth_forgot_password.yaml
@@ -5,7 +5,27 @@ env:
   TEST_EMAIL: "maestro-jul8@test.com"
 ---
 # Auth flow: navigate to forgot password, submit email, verify alert.
-# Assumes we are on the login screen (splash already dismissed).
+# Self-sufficient: launches the app and logs out first if a session is active
+# (forgot-password lives on the login screen).
+
+- launchApp
+
+- runFlow: skip_onboarding.yaml
+
+- extendedWaitUntil:
+    visible:
+      id: "HomeScreen"
+    timeout: 8000
+    optional: true
+
+- runFlow:
+    when:
+      visible:
+        id: "HomeScreen"
+    commands:
+      - runFlow: auth_logout.yaml
+
+- runFlow: skip_login_splash.yaml
 
 - tapOn: "Forgot Password?"
 

--- a/.maestro/auth_logout.yaml
+++ b/.maestro/auth_logout.yaml
@@ -1,25 +1,40 @@
 appId: register.edu.slu.cs.oss.lrda
 ---
-# Auth flow: logout from the app.
-# Assumes we are already logged in and on the tabs screen.
-# Logout lives on the profile page, reached via the avatar on the More tab.
+# Auth flow: logout from the app. Self-sufficient: launches the app and only
+# performs the logout taps if a session is active; ends on the login screen
+# either way. Logout lives on the profile page, reached via the More-tab avatar.
 
-- tapOn:
-    id: "tab-more"
+- launchApp
+
+- runFlow: skip_onboarding.yaml
+
+# Give an existing session time to land on Home before deciding
 - extendedWaitUntil:
     visible:
-      id: "profile-button"
-    timeout: 10000
-- tapOn:
-    id: "profile-button"
+      id: "HomeScreen"
+    timeout: 8000
+    optional: true
 
-- extendedWaitUntil:
-    visible:
-      id: "logout-button"
-    timeout: 10000
-- tapOn:
-    id: "logout-button"
+- runFlow:
+    when:
+      visible:
+        id: "HomeScreen"
+    commands:
+      - runFlow: skip_tutorial.yaml
+      - tapOn:
+          id: "tab-more"
+      - extendedWaitUntil:
+          visible:
+            id: "profile-button"
+          timeout: 10000
+      - tapOn:
+          id: "profile-button"
+      - extendedWaitUntil:
+          visible:
+            id: "logout-button"
+          timeout: 10000
+      - tapOn:
+          id: "logout-button"
 
-- extendedWaitUntil:
-    visible: "Login"
-    timeout: 10000
+# Ends on the login screen (skip_login_splash asserts the login button)
+- runFlow: skip_login_splash.yaml

--- a/.maestro/auth_register.yaml
+++ b/.maestro/auth_register.yaml
@@ -1,4 +1,6 @@
 appId: register.edu.slu.cs.oss.lrda
+tags:
+  - manual
 env:
   TEST_FIRST_NAME: ""
   TEST_LAST_NAME: ""

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,1 +1,7 @@
 appId: register.edu.slu.cs.oss.lrda
+
+# Helpers are subflows, not tests; auth_register is manual-only (creates a
+# real account and needs throwaway credentials edited into its env defaults).
+excludeTags:
+  - helper
+  - manual

--- a/.maestro/nav_tabs.yaml
+++ b/.maestro/nav_tabs.yaml
@@ -1,9 +1,9 @@
 appId: register.edu.slu.cs.oss.lrda
 ---
 # Smoke test: visit every tab and verify each screen renders.
-# Assumes a logged-in session; run auth_login.yaml first if needed.
+# Logs in first if needed (auth_login is idempotent).
 
-- launchApp
+- runFlow: auth_login.yaml
 
 - runFlow: skip_tutorial.yaml
 

--- a/.maestro/note_create_publish.yaml
+++ b/.maestro/note_create_publish.yaml
@@ -1,9 +1,9 @@
 appId: register.edu.slu.cs.oss.lrda
 ---
 # Note flow: create a note via the center tab button, fill it in, and publish.
-# Assumes a logged-in session; run auth_login.yaml first if needed.
+# Logs in first if needed (auth_login is idempotent).
 
-- launchApp
+- runFlow: auth_login.yaml
 
 - runFlow: skip_tutorial.yaml
 

--- a/.maestro/note_discard_empty.yaml
+++ b/.maestro/note_discard_empty.yaml
@@ -2,9 +2,10 @@ appId: register.edu.slu.cs.oss.lrda
 ---
 # Note flow: open the note editor via the center tab button and back out
 # without entering anything. No empty "Untitled" draft should be saved.
-# Assumes a logged-in session whose private notes contain no "Untitled" notes.
+# Data precondition: the account's private notes contain no "Untitled" notes.
+# Logs in first if needed (auth_login is idempotent).
 
-- launchApp
+- runFlow: auth_login.yaml
 
 - runFlow: skip_tutorial.yaml
 

--- a/.maestro/note_edit_draft.yaml
+++ b/.maestro/note_edit_draft.yaml
@@ -2,9 +2,10 @@ appId: register.edu.slu.cs.oss.lrda
 ---
 # Note flow: open the first private note in the editor, then back out
 # (the back arrow saves it as a draft and returns home).
-# Assumes a logged-in session with at least one private note.
+# Data precondition: the account has at least one private note.
+# Logs in first if needed (auth_login is idempotent).
 
-- launchApp
+- runFlow: auth_login.yaml
 
 - runFlow: skip_tutorial.yaml
 

--- a/.maestro/skip_login_splash.yaml
+++ b/.maestro/skip_login_splash.yaml
@@ -1,4 +1,6 @@
 appId: register.edu.slu.cs.oss.lrda
+tags:
+  - helper
 ---
 # The login screen shows a "Where's Religion?" splash for 2 seconds.
 # Tap to dismiss it, then wait for the login form to appear.

--- a/.maestro/skip_onboarding.yaml
+++ b/.maestro/skip_onboarding.yaml
@@ -1,4 +1,6 @@
 appId: register.edu.slu.cs.oss.lrda
+tags:
+  - helper
 ---
 # Skip the onboarding carousel (only appears on first launch).
 # The onboarding "Skip" button completes onboarding and navigates to login.

--- a/.maestro/skip_tutorial.yaml
+++ b/.maestro/skip_tutorial.yaml
@@ -1,4 +1,6 @@
 appId: register.edu.slu.cs.oss.lrda
+tags:
+  - helper
 ---
 # First-run tutorial tooltips render as a single flattened accessibility
 # element, so the Okay button cannot be targeted by id or text. Each tap on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,5 +97,5 @@ Maestro E2E flows live in `.maestro/` (auth flows; see `.maestro/config.yaml`).
 ## Known Issues
 
 - Web compilation fails (react-native-maps)
-- iOS note scroller sometimes doesn't work on Add/Edit screens
+- iOS note editor scroll overshoots into blank space past the end of long notes (editor WebView is full-screen height inside the outer ScrollView; see NoteEditorBody in lib/components/NoteEditor.tsx)
 - Android note positioning is off-center on map

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The app uses native modules (such as react-native-maps) that are not included in
 ## Known Bugs
 
 - The app does not compile to the web due to a dependency on react-native-maps.
-- Scroller on add note and edit note sometimes do not work on IOS
+- iOS note editor (Add/Edit): scrolling toward the end of a long note can run past the content into blank space, hiding the text until you scroll back up. The editor WebView is sized to the full screen inside the outer ScrollView, so its document is much taller than its content.
 - The notes orientation on map page for android is off centered.
 
 ## License


### PR DESCRIPTION
## Summary

Two release-stability items:

**1. The Maestro suite now passes as a plain directory run.** Previously `maestro test .maestro/` failed up to half its flows depending on execution order: nav/note flows assumed a logged-in session, auth flows assumed the login screen, and helper subflows ran standalone. Changes:

- nav_tabs, note_create_publish, note_discard_empty, note_edit_draft start with `runFlow: auth_login.yaml` (idempotent: skips login when a session is active)
- auth_logout and auth_forgot_password are self-sufficient: they launch the app and handle both logged-in and logged-out starting states
- skip_* helpers are tagged `helper`, auth_register is tagged `manual` (it needs throwaway credentials edited into its env defaults and creates a real backend account); config.yaml excludes both tags from directory runs

Verified: full `maestro test .maestro/` run passes 8/8 flows, with helpers/manual correctly excluded. This also unblocks running E2E in CI later.

**2. The iOS scroller known issue is rewritten with the actual repro.** Retested on the simulator (long note, keyboard open, both Add and Edit screens): scrolling works in both directions and typing follows the caret, but scrolling toward the end of a long note overshoots past the content into blank space, hiding the text until you scroll back up. Cause: NoteEditorBody gives the tentap WebView full-screen height (`ios:h-full`) inside the outer ScrollView, so the WebView document is far taller than its content. README and CLAUDE.md now describe that instead of "scroller sometimes does not work". The fix is left for a follow-up PR.

## Testing

- maestro test .maestro/ : 8/8 flows passed (4m15s)
- Scroller repro screenshots captured on iPhone 17 Pro simulator, iOS 26.3