### PR TITLE
Fix iOS editor overscroll and restore the keyboard-tracking toolbar

### DIFF
--- a/.maestro/note_create_publish.yaml
+++ b/.maestro/note_create_publish.yaml
@@ -23,9 +23,10 @@ appId: register.edu.slu.cs.oss.lrda
 - waitForAnimationToEnd
 - inputText: "Created by the note_create_publish Maestro flow."
 
-# Dismiss the keyboard; the tab bar (and its Publish button) hides while
-# the keyboard is open (tabBarHideOnKeyboard)
-- tapOn: "Done"
+# Dismiss the keyboard via the toolbar chevron; the tab bar (and its
+# Publish button) hides while the keyboard is open (tabBarHideOnKeyboard)
+- tapOn:
+    id: "doneButton"
 - waitForAnimationToEnd
 
 # The center tab button becomes Publish inside the editor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,5 +97,4 @@ Maestro E2E flows live in `.maestro/` (auth flows; see `.maestro/config.yaml`).
 ## Known Issues
 
 - Web compilation fails (react-native-maps)
-- iOS note editor scroll overshoots into blank space past the end of long notes (editor WebView is full-screen height inside the outer ScrollView; see NoteEditorBody in lib/components/NoteEditor.tsx)
 - Android note positioning is off-center on map

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ The app uses native modules (such as react-native-maps) that are not included in
 ## Known Bugs
 
 - The app does not compile to the web due to a dependency on react-native-maps.
-- iOS note editor (Add/Edit): scrolling toward the end of a long note can run past the content into blank space, hiding the text until you scroll back up. The editor WebView is sized to the full screen inside the outer ScrollView, so its document is much taller than its content.
 - The notes orientation on map page for android is off centered.
 
 ## License

--- a/lib/components/NoteEditor.tsx
+++ b/lib/components/NoteEditor.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { Dimensions, TextInput, TouchableOpacity, View } from "react-native";
+import { Dimensions, Platform, TextInput, TouchableOpacity, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import Constants from "expo-constants";
-import { RichText, type EditorBridge } from "@10play/tentap-editor";
+import { DEFAULT_TOOLBAR_ITEMS, RichText, Toolbar, type EditorBridge } from "@10play/tentap-editor";
 import PhotoScroller from "./photoScroller";
 import AudioContainer from "./audio";
 import TagWindow from "./tagging";
@@ -122,6 +122,42 @@ export function NoteEditorPanels({
   );
 }
 
+interface NoteEditorToolbarProps {
+  editor: EditorBridge;
+  keyboardVisible: boolean;
+  keyboardHeight: number;
+  /** Dismiss the keyboard (the chevron-down button). */
+  onDone: () => void;
+}
+
+/**
+ * Formatting toolbar pinned flush above the keyboard, with a keyboard-dismiss
+ * button on the right. Rendered as a sibling of the KeyboardAvoidingView so
+ * `bottom: keyboardHeight` is measured from the screen edge.
+ */
+export function NoteEditorToolbar({ editor, keyboardVisible, keyboardHeight, onDone }: NoteEditorToolbarProps) {
+  return (
+    <View
+      className="absolute left-0 z-20 h-[50px] w-full flex-row items-center overflow-hidden rounded-t-[18px] bg-white"
+      style={{
+        bottom: keyboardVisible ? (Platform.OS === "android" ? keyboardHeight + 20 : keyboardHeight) : 0,
+        display: keyboardVisible ? "flex" : "none",
+      }}
+      pointerEvents={keyboardVisible ? "auto" : "none"}
+      testID="Toolbar"
+    >
+      {/* 105% height nudges the Toolbar up to clip its built-in top border,
+          which cannot be styled directly. */}
+      <View className="h-[105%] flex-1 justify-center">
+        <Toolbar editor={editor} items={DEFAULT_TOOLBAR_ITEMS} />
+      </View>
+      <TouchableOpacity testID="doneButton" onPress={onDone} className="z-30 h-full items-center justify-center px-3">
+        <Ionicons name="chevron-down" size={28} color="#007AFF" />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
 interface NoteEditorBodyProps {
   editor: EditorBridge;
   testID?: string;
@@ -130,16 +166,14 @@ interface NoteEditorBodyProps {
 export function NoteEditorBody({ editor, testID }: NoteEditorBodyProps) {
   const { colors } = useTheme();
   return (
-    <View className="ios:h-full android:flex-1 min-h-[300px] grow pb-[120px]" testID={testID}>
+    <View className="min-h-[300px] flex-1" testID={testID}>
       <RichText
         editor={editor}
         style={{
           flex: 1,
           width: "100%",
           minHeight: 200,
-          paddingBottom: 120,
           padding: 10,
-          marginBottom: 4,
           backgroundColor: colors.primary,
         }}
       />

--- a/lib/hooks/useNoteEditor.ts
+++ b/lib/hooks/useNoteEditor.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Keyboard } from "react-native";
+import { Keyboard, Platform } from "react-native";
 import { useEditorBridge } from "@10play/tentap-editor";
 import { useTheme } from "../components/ThemeProvider";
 
@@ -18,17 +18,25 @@ export function isBodyEmpty(htmlString: string): boolean {
 
 export function useKeyboardVisible() {
   const [keyboardVisible, setKeyboardVisible] = useState(false);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
 
   useEffect(() => {
-    const showListener = Keyboard.addListener("keyboardDidShow", () => setKeyboardVisible(true));
-    const hideListener = Keyboard.addListener("keyboardDidHide", () => setKeyboardVisible(false));
+    // will* events fire on iOS only; they track the keyboard animation so the
+    // toolbar moves in step with it instead of jumping after it settles.
+    const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
+    const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
+    const showListener = Keyboard.addListener(showEvent, (event) => {
+      setKeyboardVisible(true);
+      setKeyboardHeight(event.endCoordinates.height);
+    });
+    const hideListener = Keyboard.addListener(hideEvent, () => setKeyboardVisible(false));
     return () => {
       showListener.remove();
       hideListener.remove();
     };
   }, []);
 
-  return keyboardVisible;
+  return { keyboardVisible, keyboardHeight };
 }
 
 /**
@@ -48,6 +56,12 @@ export function useNoteEditor(initialContent: string) {
         ${customImageCSS}
         body {
           color: ${colors.foreground};
+        }
+        /* Keeps the last lines reachable above the overlaid toolbar. Inside
+           the document (not the native container) so the whole body area
+           stays tappable WebView. */
+        .ProseMirror {
+          padding-bottom: 80px;
         }
       `;
       editor.injectCSS(combinedCSS);

--- a/lib/screens/AddNoteScreen.tsx
+++ b/lib/screens/AddNoteScreen.tsx
@@ -2,9 +2,8 @@ import React, { useEffect, useEffectEvent, useRef, useState } from "react";
 import { View, TouchableOpacity, Platform, KeyboardAvoidingView, Modal, ScrollView, Text, StatusBar } from "react-native";
 import ToastMessage from "react-native-toast-message";
 
-import { DEFAULT_TOOLBAR_ITEMS, Toolbar } from "@10play/tentap-editor";
 import LoadingModal from "../components/LoadingModal";
-import { NoteEditorHeader, NoteEditorActionRow, NoteEditorPanels, NoteEditorBody } from "../components/NoteEditor";
+import { NoteEditorHeader, NoteEditorActionRow, NoteEditorPanels, NoteEditorBody, NoteEditorToolbar } from "../components/NoteEditor";
 import { VideoView, useVideoPlayer } from "expo-video";
 import { getHasDoneTutorial, setTutorialDone } from "../utils/tutorial";
 import type { AudioType, Media } from "../models/media_class";
@@ -34,7 +33,7 @@ const AddNoteScreen: React.FC = () => {
   const [videoUri] = useState<string | null>(null);
   const videoPlayer = useVideoPlayer(videoUri);
   const { location, isLocationOff, toggleLocation } = useNoteLocation();
-  const keyboardVisible = useKeyboardVisible();
+  const { keyboardVisible, keyboardHeight } = useKeyboardVisible();
   const { setPublishNote } = useAddNoteContext();
   const bodyTextRef = useRef(bodyText);
   const tagsRef = useRef(tags);
@@ -236,19 +235,7 @@ const AddNoteScreen: React.FC = () => {
               insertAudioToEditor={insertAudioToEditor}
             />
             <NoteEditorBody editor={editor} testID="TenTapEditor" />
-
-            <View className="ios:h-[50px] android:h-[70px] absolute bottom-[27px] z-10 w-full justify-center px-[10px]" testID="RichEditor">
-              <Toolbar editor={editor} items={DEFAULT_TOOLBAR_ITEMS} />
-            </View>
-            {Platform.OS === "ios" && <Toolbar editor={editor} items={DEFAULT_TOOLBAR_ITEMS} />}
           </View>
-          {keyboardVisible && (
-            <View className="absolute bottom-0 z-10 w-full border-[#ddd] bg-white py-[5px]" testID="doneButton">
-              <TouchableOpacity onPress={handleDonePress}>
-                <Text className="mr-[25px] p-0 text-right font-inter text-[14px] text-blue-500">Done</Text>
-              </TouchableOpacity>
-            </View>
-          )}
         </ScrollView>
         <Modal animationType="slide" transparent={true} visible={isVideoModalVisible} onRequestClose={() => setIsVideoModalVisible(false)}>
           <View className="flex-1 items-center justify-center bg-black/50">
@@ -263,6 +250,8 @@ const AddNoteScreen: React.FC = () => {
 
         <LoadingModal visible={createNoteMutation.isPending} />
       </KeyboardAvoidingView>
+
+      <NoteEditorToolbar editor={editor} keyboardVisible={keyboardVisible} keyboardHeight={keyboardHeight} onDone={handleDonePress} />
     </View>
   );
 };

--- a/lib/screens/EditNoteScreen.tsx
+++ b/lib/screens/EditNoteScreen.tsx
@@ -1,14 +1,13 @@
 import React, { useState, useEffect, useEffectEvent, useRef, useMemo } from "react";
-import { View, TouchableOpacity, KeyboardAvoidingView, Platform, ScrollView, Text } from "react-native";
+import { View, KeyboardAvoidingView, Platform, ScrollView } from "react-native";
 import ToastMessage from "react-native-toast-message";
 import { useAuthStore } from "../stores/authStore";
 import type { Media, AudioType } from "../models/media_class";
 import { useUpdateNote } from "../hooks/mutations/useUpdateNote";
 import { useNoteLocation } from "../hooks/useNoteLocation";
 import { useNoteEditor, useKeyboardVisible } from "../hooks/useNoteEditor";
-import { DEFAULT_TOOLBAR_ITEMS, Toolbar } from "@10play/tentap-editor";
 import LoadingModal from "../components/LoadingModal";
-import { NoteEditorHeader, NoteEditorActionRow, NoteEditorPanels, NoteEditorBody } from "../components/NoteEditor";
+import { NoteEditorHeader, NoteEditorActionRow, NoteEditorPanels, NoteEditorBody, NoteEditorToolbar } from "../components/NoteEditor";
 import { useAddNoteContext } from "../context/AddNoteContext";
 import { useAddNoteStore } from "../stores/addNoteStore";
 import { useRouter, useLocalSearchParams, useNavigation } from "expo-router";
@@ -25,7 +24,7 @@ const EditNoteScreen = () => {
       return {};
     }
   }, [noteData]);
-  const keyboardVisible = useKeyboardVisible();
+  const { keyboardVisible, keyboardHeight } = useKeyboardVisible();
 
   const [title, setTitle] = useState(note.title || "Untitled");
   const [time] = useState(new Date(note.time));
@@ -193,28 +192,12 @@ const EditNoteScreen = () => {
           />
 
           <NoteEditorBody editor={editor} />
-
-          {Platform.OS === "ios" && (
-            <View className="absolute bottom-[27px] z-10 h-[50px] w-full justify-center px-[10px]" testID="Toolbar">
-              <Toolbar editor={editor} items={DEFAULT_TOOLBAR_ITEMS} />
-            </View>
-          )}
-          {keyboardVisible && (
-            <View className="absolute right-4 z-10" style={{ bottom: 7 }} testID="doneButton">
-              <TouchableOpacity onPress={handleDonePress}>
-                <Text className="text-right text-[14px] text-blue-500">Done</Text>
-              </TouchableOpacity>
-            </View>
-          )}
-          {Platform.OS === "android" && (
-            <View className="absolute bottom-[27px] z-10 h-[50px] w-full justify-center px-[10px]" testID="Toolbar">
-              <Toolbar editor={editor} items={DEFAULT_TOOLBAR_ITEMS} />
-            </View>
-          )}
         </ScrollView>
 
         <LoadingModal visible={updateNoteMutation.isPending} />
       </KeyboardAvoidingView>
+
+      <NoteEditorToolbar editor={editor} keyboardVisible={keyboardVisible} keyboardHeight={keyboardHeight} onDone={handleDonePress} />
     </View>
   );
 };


### PR DESCRIPTION
## Summary

Closes out the iOS note editor known issue and restores the nicer toolbar design from closed PR #262.

**Overscroll fix.** `NoteEditorBody` gave the tentap WebView full-screen height (`ios:h-full`) inside the outer ScrollView, so the WebView document was far taller than its content: scrolling toward the end of a long note ran past the text into blank space, hiding the whole note. The body is now `flex-1` on both platforms (Android already was, and did not have the bug), and the toolbar breathing room lives inside the document as ProseMirror `padding-bottom` CSS instead of native container padding, so the entire body area stays tappable WebView. Scrolling now stops at the end of the text on both Add and Edit screens. The known-issue lines are removed from README and CLAUDE.md.

**Toolbar port from PR #262.** The editors rendered the tentap Toolbar twice on iOS plus a full-width white "Done" bar pinned to the screen bottom. Ported the closed-PR treatment into the shared components:

- `useKeyboardVisible` now also reports keyboard height, using `keyboardWillShow/Hide` on iOS so the toolbar tracks the keyboard animation
- new shared `NoteEditorToolbar` sits flush above the keyboard (rounded top, built-in border clipped via the 105% wrapper trick), with a blue chevron-down dismiss button on the right
- both screens drop their duplicated toolbar/Done JSX for the shared component, rendered outside the KeyboardAvoidingView so `bottom: keyboardHeight` measures from the screen edge
- `note_create_publish` flow taps the chevron by id since there is no "Done" text anymore

## Testing

- Maestro directory suite: 8/8 flows passed
- Scroller repro flows (long note, keyboard open, scroll both directions, Add + Edit): text stays visible, scroll stops at the end of content
- pnpm test: 39 passing; tsc and eslint clean