### PR TITLE
Patch the css-interop Metro crash and add a pnpm e2e preflight runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,9 @@ Run a single test file:
 pnpm test __tests__/api_calls.test.ts
 ```
 
-Maestro E2E flows live in `.maestro/` (auth flows; see `.maestro/config.yaml`).
+Maestro E2E flows live in `.maestro/` (see `.maestro/config.yaml`). Run them with `pnpm e2e` (full suite) or `pnpm e2e <flow-name>` (single flow) — the script checks backend health, boots the simulator, fixes the hardware-keyboard/GPS settings, and starts Metro if needed before invoking Maestro. The backend must be running from the sibling `lrda_website` repo.
+
+`react-native-css-interop` is patched (`patches/`) to stop its CSS fast-refresh event from crashing Metro on newer Metro versions (nativewind/nativewind#1786); drop the patch if a fixed upstream release ships.
 
 ## Code Style
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "jest",
     "test:update": "jest -u",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "e2e": "bash scripts/e2e.sh"
   },
   "dependencies": {
     "@10play/tentap-editor": "^0.5.23",

--- a/patches/react-native-css-interop.patch
+++ b/patches/react-native-css-interop.patch
@@ -1,0 +1,29 @@
+diff --git a/dist/metro/index.js b/dist/metro/index.js
+index c91ba6adf049dd5c6eec1ec8301ecc0802f41bfc..1fe79d48190a953375ad641120085eb578c5e7f8 100644
+--- a/dist/metro/index.js
++++ b/dist/metro/index.js
+@@ -177,6 +177,7 @@ async function startCSSProcessor(filePath, platform, isDev, { input, getCSSForPl
+                 : getNativeJS((0, css_to_rn_1.cssToReactNativeRuntime)(css, options), debug)));
+             debug(`virtualStyles.emit ${platform}`);
+             haste.emit("change", {
++                // Legacy Metro shape (kept for compatibility)
+                 eventsQueue: [
+                     {
+                         filePath,
+@@ -188,6 +189,16 @@ async function startCSSProcessor(filePath, platform, isDev, { input, getCSSForPl
+                         type: "change",
+                     },
+                 ],
++                // Modern Metro (SDK 56 / RN 0.85) reads { changes, rootDir } in
++                // DependencyGraph._onHasteChange; without these the emit crashes
++                // the dev server (nativewind/nativewind#1786). Empty maps still
++                // trigger the resolution-cache flush and "change" re-emit.
++                changes: {
++                    addedFiles: new Map(),
++                    modifiedFiles: new Map(),
++                    removedFiles: new Map(),
++                },
++                rootDir: "",
+             });
+         }).then((css) => {
+             debug(`virtualStyles.initial ${platform}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   eslint-plugin-react-hooks: ^7.1.1
 
+patchedDependencies:
+  react-native-css-interop:
+    hash: a6f8b6f0a546205ad1062c7dac6c0f0533a1a466e4ae4c2d5eb4e168dd3e3355
+    path: patches/react-native-css-interop.patch
+
 importers:
 
   .:
@@ -11433,7 +11438,7 @@ snapshots:
     dependencies:
       comment-json: 4.6.2
       debug: 4.4.3
-      react-native-css-interop: 0.2.3(56d0878c846e4c5bd2330f33abce12e2)
+      react-native-css-interop: 0.2.3(patch_hash=a6f8b6f0a546205ad1062c7dac6c0f0533a1a466e4ae4c2d5eb4e168dd3e3355)(56d0878c846e4c5bd2330f33abce12e2)
       tailwindcss: 3.4.17
     transitivePeerDependencies:
       - react
@@ -11921,7 +11926,7 @@ snapshots:
     dependencies:
       prop-types: 15.8.1
 
-  react-native-css-interop@0.2.3(56d0878c846e4c5bd2330f33abce12e2):
+  react-native-css-interop@0.2.3(patch_hash=a6f8b6f0a546205ad1062c7dac6c0f0533a1a466e4ae4c2d5eb4e168dd3e3355)(56d0878c846e4c5bd2330f33abce12e2):
     dependencies:
       '@babel/helper-module-imports': 7.28.6
       '@babel/traverse': 7.29.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
-overrides:
-  eslint-plugin-react-hooks: ^7.1.1
-
 onlyBuiltDependencies:
   - unrs-resolver
+overrides:
+  eslint-plugin-react-hooks: ^7.1.1
+patchedDependencies:
+  react-native-css-interop: patches/react-native-css-interop.patch

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Preflight checks + run the Maestro E2E suite.
+#
+# Usage:
+#   pnpm e2e              run the full suite (.maestro/)
+#   pnpm e2e nav_tabs     run a single flow by name
+#
+# Automates the setup steps that otherwise silently break flows: backend
+# health, simulator boot, hardware-keyboard setting, GPS fix (resets on
+# every simulator reboot), Metro health, and a warm app launch.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+APP_ID="register.edu.slu.cs.oss.lrda"
+SIM_LOCATION="38.6357,-90.2340"
+API_HEALTH="http://localhost:3002/api/health"
+METRO_STATUS="http://localhost:8081/status"
+METRO_LOG="/tmp/lrda-metro.log"
+
+fail() { printf '\033[31m✖ %s\033[0m\n' "$*"; exit 1; }
+ok()   { printf '\033[32m✔ %s\033[0m\n' "$*"; }
+
+# 1. Backend API (run from the sibling lrda_website repo)
+curl -sf -m 3 "$API_HEALTH" > /dev/null \
+  || fail "Backend not responding at $API_HEALTH. In lrda_website: pnpm api:docker:up && pnpm dev:api"
+ok "Backend API healthy"
+
+# 2. Simulator booted
+if ! xcrun simctl list devices booted | grep -q Booted; then
+  echo "No booted simulator; booting the first available iPhone..."
+  UDID=$(xcrun simctl list devices available | grep iPhone | grep -m1 -oE '[0-9A-F-]{36}')
+  [ -n "$UDID" ] || fail "No available iPhone simulator found"
+  xcrun simctl boot "$UDID"
+  open -a Simulator
+  sleep 10
+fi
+ok "Simulator booted"
+
+# 3. Hardware keyboard must be off or simulated typing never lands
+HK=$(defaults read com.apple.iphonesimulator ConnectHardwareKeyboard 2>/dev/null || echo unset)
+if [ "$HK" != "0" ]; then
+  defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false
+  fail "ConnectHardwareKeyboard was on; turned it off. Quit and reopen Simulator.app, then rerun."
+fi
+ok "Hardware keyboard off"
+
+# 4. GPS fix (silently resets on simulator reboot)
+xcrun simctl location booted set "$SIM_LOCATION"
+ok "GPS fix set ($SIM_LOCATION)"
+
+# 5. Metro dev server
+if ! curl -sf -m 2 "$METRO_STATUS" | grep -q running; then
+  echo "Metro not running; starting (log: $METRO_LOG)..."
+  nohup pnpm start > "$METRO_LOG" 2>&1 &
+  for _ in $(seq 1 30); do
+    curl -sf -m 2 "$METRO_STATUS" 2>/dev/null | grep -q running && break
+    sleep 2
+  done
+  curl -sf -m 2 "$METRO_STATUS" | grep -q running || fail "Metro failed to start; see $METRO_LOG"
+fi
+ok "Metro running"
+
+# 6. Fresh app launch so the first flow doesn't pay the bundle-build wait
+xcrun simctl terminate booted "$APP_ID" 2>/dev/null || true
+xcrun simctl launch booted "$APP_ID" > /dev/null \
+  || fail "App $APP_ID is not installed on the simulator. Run: pnpm ios"
+echo "Warming up the app bundle..."
+sleep 15
+ok "App launched"
+
+# 7. Run Maestro
+if [ $# -gt 0 ]; then
+  exec maestro test ".maestro/$1.yaml"
+fi
+exec maestro test .maestro/


### PR DESCRIPTION
## Summary

Two dev-workflow reliability fixes, prompted by Metro dying three times in one working session.

**Metro crash patch.** Metro crashed with exit 7 (`TypeError: Cannot read properties of undefined (reading 'addedFiles')`) whenever an edit produced new Tailwind CSS. Root cause: react-native-css-interop's CSS fast-refresh path emits a hand-rolled haste change event in the legacy `{ eventsQueue }` shape, but Metro in SDK 56 destructures `{ changes, rootDir }` in `DependencyGraph._onHasteChange`. This is nativewind/nativewind#1786, still open upstream with no fixed release, so this is a `pnpm patch` that adds the modern fields (empty change maps still trigger the resolution-cache flush) alongside the legacy ones. Verified by making new-CSS className edits against a running dev server: previously a reliable kill, now survives cleanly. CLAUDE.md notes to drop the patch once upstream ships a fix.

**`pnpm e2e` preflight runner** (`scripts/e2e.sh`). Every E2E session needs the same fragile setup, and each missed step fails in a confusing way (typing silently not landing, flows dying on basic elements, location errors). The script automates all of it before invoking Maestro:

- backend API health check (with the lrda_website startup hint on failure)
- simulator boot if none is running
- ConnectHardwareKeyboard check (simulated typing silently fails when it is on)
- GPS fix (silently resets on every simulator reboot)
- Metro start-if-down with health wait
- fresh app launch so the first flow does not pay the bundle-build wait

`pnpm e2e` runs the full suite; `pnpm e2e <flow-name>` runs one flow.

## Testing

- Verified `pnpm e2e nav_tabs` from a cold state (Metro down): the script brought everything up and the flow passed
- Crash repro against the patched module: two new-CSS edits with the dev server and app connected, Metro stayed alive, no addedFiles error in the log
- pnpm test: 39 passing